### PR TITLE
LibraryCallMonitor plugin rewrite

### DIFF
--- a/src/s2e/Plugins/ExecutionMonitors/LibraryCallMonitor.h
+++ b/src/s2e/Plugins/ExecutionMonitors/LibraryCallMonitor.h
@@ -1,80 +1,71 @@
 ///
-/// Copyright (C) 2011-2013, Dependable Systems Laboratory, EPFL
+/// Copyright (C) 2011-2017, Dependable Systems Laboratory, EPFL
+/// Copyright (C) 2016, Cyberhaven
 /// All rights reserved.
 ///
 /// Licensed under the Cyberhaven Research License Agreement.
 ///
 
-#ifndef S2E_PLUGINS_LIBCALLMON_H
-#define S2E_PLUGINS_LIBCALLMON_H
+#ifndef S2E_PLUGINS_LibraryCallMonitor_H
+#define S2E_PLUGINS_LibraryCallMonitor_H
 
-#include <s2e/CorePlugin.h>
 #include <s2e/Plugin.h>
-#include <s2e/S2EExecutionState.h>
-
-#include <string>
-#include <tr1/unordered_map>
-#include <tr1/unordered_set>
-
-#include <s2e/Plugins/OSMonitors/Support/ModuleExecutionDetector.h>
-#include "FunctionMonitor.h"
 
 namespace s2e {
+
+class S2E;
+class S2EExecutionState;
+
 namespace plugins {
 
+class ModuleMap;
 class OSMonitor;
+class ProcessExecutionDetector;
 
+///
+/// \brief Monitors external library function calls.
+///
+/// This plugin can be used to determine what external library calls a particular module makes at run time. The
+/// modules to monitor are those defined in the \code ProcessExecutionDetector plugin's config.
+///
+/// The plugin works as follows:
+///   \li All indirect calls are monitored. Library calls are always made indirectly (via either the PLT in ELF
+///       binaries or the IAT in PE binaries)
+///   \li When an indirect call is made, we look up the module that contains the call target address
+///   \li Once we find that module, we can search its export table to find an entry that matches the call target
+///       address. If a match is found, report it
+///
+/// Note that this approach does not use the callee module's import table. This means that library calls that are not
+/// listed in the import table are still monitored. This is beneficial for malware analysis, where the import table
+/// is often destroyed and library calls are made "indirectly" (e.g. via \code LoadLibrary and \code GetProcAddress).
+///
 class LibraryCallMonitor : public Plugin {
     S2E_PLUGIN
-public:
-    typedef std::tr1::unordered_set<std::string> StringSet;
-    typedef std::set<std::pair<uint64_t, uint64_t>> AddressPairs;
 
+public:
     LibraryCallMonitor(S2E *s2e) : Plugin(s2e) {
     }
 
     void initialize();
 
-    sigc::signal<void, S2EExecutionState *, FunctionMonitorState *,
-                 const ModuleDescriptor & /* The module  being called */>
+    /// Emitted on an external library function call.
+    sigc::signal<void, S2EExecutionState *, /* The current execution state */
+                 const ModuleDescriptor &,  /* The module that made the library call */
+                 uint64_t>                  /* The called function's address */
         onLibraryCall;
 
 private:
+    ModuleMap *m_map;
     OSMonitor *m_monitor;
-    ModuleExecutionDetector *m_detector;
-    FunctionMonitor *m_functionMonitor;
-    StringSet m_functionNames;
-    AddressPairs m_alreadyCalledFunctions;
+    ProcessExecutionDetector *m_procDetector;
 
-    // List of modules whose calls we want to track.
-    // Empty to track all modules in the system.
-    StringSet m_trackedModules;
-
-    bool m_displayOnce;
-
-    void onModuleLoad(S2EExecutionState *state, const ModuleDescriptor &module);
-
-    void onModuleUnload(S2EExecutionState *state, const ModuleDescriptor &module);
-    void onFunctionCall(S2EExecutionState *state, FunctionMonitorState *fns);
-};
-
-class LibraryCallMonitorState : public PluginState {
-public:
-    typedef std::tr1::unordered_map<uint64_t, const char *> AddressToFunctionName;
-
-private:
-    AddressToFunctionName m_functions;
-
-public:
-    LibraryCallMonitorState();
-    virtual ~LibraryCallMonitorState();
-    virtual LibraryCallMonitorState *clone() const;
-    static PluginState *factory(Plugin *p, S2EExecutionState *s);
-
-    friend class LibraryCallMonitor;
+    void onTranslateBlockEnd(ExecutionSignal *signal, S2EExecutionState *state, TranslationBlock *tb, uint64_t pc,
+                             bool isStatic, uint64_t staticTarget);
+    void onIndirectCall(S2EExecutionState *state, uint64_t pc);
+    void handleAPICall(uint64_t address, const ModuleDescriptorList &mods);
 };
 
 } // namespace plugins
 } // namespace s2e
 
-#endif // S2E_PLUGINS_LIBCALLMON_H
+#endif

--- a/src/s2e/Plugins/OSMonitors/Support/ModuleExecutionDetector.cpp
+++ b/src/s2e/Plugins/OSMonitors/Support/ModuleExecutionDetector.cpp
@@ -313,7 +313,6 @@ void ModuleExecutionDetector::moduleLoadListener(S2EExecutionState *state, const
             plgState->loadDescriptor(module, false);
             onModuleLoad.emit(state, module);
         }
-        return;
     }
 }
 

--- a/src/s2e/Plugins/OSMonitors/Support/ModuleMap.cpp
+++ b/src/s2e/Plugins/OSMonitors/Support/ModuleMap.cpp
@@ -156,17 +156,17 @@ void ModuleMap::initialize() {
 
     m_monitor->onModuleUnload.connect(sigc::mem_fun(*this, &ModuleMap::onModuleUnload));
 
-    WindowsMonitor *winmon2 = dynamic_cast<WindowsMonitor *>(m_monitor);
-    if (winmon2) {
-        winmon2->onMonitorLoad.connect(sigc::mem_fun(*this, &ModuleMap::onMonitorLoad));
+    WindowsMonitor *winmon = dynamic_cast<WindowsMonitor *>(m_monitor);
+    if (winmon) {
+        winmon->onMonitorLoad.connect(sigc::mem_fun(*this, &ModuleMap::onMonitorLoad));
     }
 }
 
 void ModuleMap::onMonitorLoad(S2EExecutionState *state) {
-    WindowsMonitor *winmon2 = dynamic_cast<WindowsMonitor *>(m_monitor);
-    if (!winmon2->moduleUnloadSupported()) {
+    WindowsMonitor *winmon = dynamic_cast<WindowsMonitor *>(m_monitor);
+    if (!winmon->moduleUnloadSupported()) {
         getDebugStream() << "Guest OS does not support native module unload, using workaround\n";
-        winmon2->onNtUnmapViewOfSection.connect(sigc::mem_fun(*this, &ModuleMap::onNtUnmapViewOfSection));
+        winmon->onNtUnmapViewOfSection.connect(sigc::mem_fun(*this, &ModuleMap::onNtUnmapViewOfSection));
     }
 }
 

--- a/src/s2e/Plugins/OSMonitors/Windows/WindowsInterceptor.cpp
+++ b/src/s2e/Plugins/OSMonitors/Windows/WindowsInterceptor.cpp
@@ -97,7 +97,7 @@ bool WindowsInterceptor::getImports(S2EExecutionState *state, const ModuleDescri
         return false;
     }
 
-    getDebugStream(state) << "getting import for " << Desc << "\n";
+    getDebugStream(state) << "getting imports for " << Desc << "\n";
 
     bool result = true;
     vmi::GuestMemoryFileProvider file(state, &Vmi::readGuestVirtual, NULL, Desc.Name);


### PR DESCRIPTION
The current LibraryCallMonitor plugin was broken if the imported DLL was not available in memory and had to be read from the guestfs. In this case, the addresses in the import address table are not valid runtime addresses and so hooking these addresses with the FunctionMonitor plugin was pointless (because these addresses would be overwritten at load time with the actual runtime address of the import).

The new LibraryCallMonitor plugin uses the ModuleMap plugin to keep track of loaded modules. When a library call occurs, we search the loaded modules to find if one of them contains the address that was called. If it does, we can find this function in the module's exports and determine the name of this function.