### PR TITLE
LibraryCallMonitor: rewrite

### DIFF
--- a/src/s2e/Plugins/OSMonitors/Support/ModuleMap.h
+++ b/src/s2e/Plugins/OSMonitors/Support/ModuleMap.h
@@ -14,6 +14,8 @@
 #include <s2e/Plugins/OSMonitors/ModuleDescriptor.h>
 #include <s2e/S2EExecutionState.h>
 
+#include <utility>
+
 namespace s2e {
 namespace plugins {
 
@@ -22,7 +24,10 @@ struct S2E_WINMON2_UNMAP_SECTION;
 
 class ModuleMap : public Plugin {
     S2E_PLUGIN
+
 public:
+    typedef std::pair<const ModuleDescriptor * /* Module */, std::string /* Exported symbol name */> Export;
+
     ModuleMap(S2E *s2e) : Plugin(s2e) {
     }
 
@@ -35,15 +40,22 @@ public:
 
     void dump(S2EExecutionState *state);
 
+    /// Cache a module export at the given address.
+    void cacheExport(S2EExecutionState *state, uint64_t address, const Export &exp);
+
+    ///
+    /// \brief Get an export at the given runtime address.
+    ///
+    /// Returns a \c nullptr if no export at the given address exists in the cache.
+    ///
+    const Export *getExport(S2EExecutionState *state, uint64_t address);
+
 private:
     OSMonitor *m_monitor;
 
     void onModuleLoad(S2EExecutionState *state, const ModuleDescriptor &module);
-
     void onModuleUnload(S2EExecutionState *state, const ModuleDescriptor &module);
-
     void onProcessUnload(S2EExecutionState *state, uint64_t addressSpace, uint64_t pid);
-
     void onNtUnmapViewOfSection(S2EExecutionState *state, const S2E_WINMON2_UNMAP_SECTION &s);
     void onMonitorLoad(S2EExecutionState *state);
 };


### PR DESCRIPTION
The current `LibraryCallMonitor` plugin was broken if the imported DLL was not available in memory and had to be read from the guestfs. In this case, the addresses in the import address table are not valid runtime addresses and so hooking these addresses with the `FunctionMonitor` plugin was pointless (because these addresses would be overwritten at load time with the actual runtime address of the import).

The new `LibraryCallMonitor` plugin uses the `ModuleMap` plugin to keep track of loaded modules. When a library call occurs, we search the loaded modules to find if one of them contains the address that was called. If it does, we can find this function in the module's exports and determine the name of this function. Exports are cached for faster lookup.