### PR TITLE
TranslationBlockCoverage: periodic JSON writes

### DIFF
--- a/src/s2e/Plugins/Coverage/TranslationBlockCoverage.h
+++ b/src/s2e/Plugins/Coverage/TranslationBlockCoverage.h
@@ -164,6 +164,8 @@ private:
     klee::StateSet m_newBlockStates;
     ModuleTBs m_localCoverage;
     GlobalCoverage m_globalCoverage;
+    unsigned m_writeCoveragePeriod;
+    unsigned m_timerTicks;
 
     void onTimer();
     void onStateKill(S2EExecutionState *state);


### PR DESCRIPTION
Sometimes a state will never terminate, either by design (e.g. the program is a service that runs in an infinite loop, etc.) or otherwise. This option allows the user the at least get _some_ coverage information in this case. By default this feature is disabled.