### PR TITLE
LinuxMonitors: refactored Linux kernel offsets

### DIFF
--- a/src/s2e/Plugins/OSMonitors/Linux/BaseLinuxMonitor.h
+++ b/src/s2e/Plugins/OSMonitors/Linux/BaseLinuxMonitor.h
@@ -26,20 +26,43 @@ extern CPUX86State *env;
 
 using namespace klee;
 
-// from arch/x86/include/asm/page_types.h
-#define PAGE_SHIFT 12
-#define PAGE_SIZE (1UL << PAGE_SHIFT)
+namespace s2e {
+namespace plugins {
 
-// from arch/x86/include/asm/page_32_types.h
-#define THREAD_SIZE_ORDER 1
-#define THREAD_SIZE (PAGE_SIZE << THREAD_SIZE_ORDER)
+namespace linux_common {
+
+// From arch/x86/include/asm/page_types.h
+static const unsigned PAGE_SHIFT = 12;
+static const unsigned PAGE_SIZE = 1UL << PAGE_SHIFT;
+
+#if defined(TARGET_I386)
+// From arch/x86/include/asm/page_32_types.h
+static const unsigned THREAD_SIZE_ORDER = 1;
+#elif defined(TARGET_X86_64)
+// From arch/x86/include/asm/page_64_types.h
+static const unsigned THREAD_SIZE_ORDER = 2;
+#else
+#error "BaseLinuxMonitor: Unsupported architecture"
+#endif
+
+// From arch/x86/include/asm/page_{32,64}_types.h
+static const unsigned THREAD_SIZE = PAGE_SIZE << THREAD_SIZE_ORDER;
 
 /// Pointer to the address of ESP0 in the Task State Segment (TSS).
 /// ESP0 is the stack pointer to load when in kernel mode
-#define TSS_ESP0_OFFSET 4
+static const unsigned TSS_ESP0_OFFSET = 4;
 
-namespace s2e {
-namespace plugins {
+///
+/// \brief The start address of the kernel
+///
+/// This is configured in the Linux kernel via the CONFIG_PAGE_OFFSET option. This is the default value for X86.
+///
+static const uint64_t KERNEL_START_ADDRESS = 0xC0000000;
+
+// TODO Get the real stack size from the process memory map
+static const uint64_t STACK_SIZE = 16 * 1024 * 1024;
+
+} // namespace linux_common
 
 ///
 /// \brief Base state for X86 Linux monitors, including the Linux and CGC monitors
@@ -83,37 +106,28 @@ public:
 /// \brief Abstract base plugin for X86 Linux monitors, including the Linux and
 /// CGC monitors
 ///
-/// This class contains a number of virtual getter methods that return values
-/// specific to the kernel in use.
+/// This class contains a number of virtual getter methods that return values specific to the kernel in use.
 ///
-/// \tparam CmdT The type of command that will be emitted by the kernel and
-/// captured by a Linux monitor plugin
+/// \tparam CmdT The type of command that will be emitted by the kernel and captured by a Linux monitor plugin
+/// \tparam CmdVersion The command version that is expected to be emitted from the kernel when an event occurs
 ///
-template <typename CmdT> class BaseLinuxMonitor : public OSMonitor, public BaseInstructionsPluginInvokerInterface {
+template <typename CmdT, uint64_t CmdVersion>
+class BaseLinuxMonitor : public OSMonitor, public BaseInstructionsPluginInvokerInterface {
 protected:
-    /// Start address of the kernel
-    const uint64_t m_kernelStartAddress;
-
-    /// Size of the stack
-    const unsigned m_stackSize;
-
-    /// The version of the monitor command to validate against
-    const uint64_t m_commandVersion;
-
     /// Terminate if a segment fault occurs
     bool m_terminateOnSegfault;
 
     /// Get the base address to the \c task_struct in the kernel
     target_ulong getTaskStructPtr(S2EExecutionState *state) {
         target_ulong esp0;
-        target_ulong esp0Addr = env->tr.base + TSS_ESP0_OFFSET;
+        target_ulong esp0Addr = env->tr.base + linux_common::TSS_ESP0_OFFSET;
 
         if (!state->mem()->readMemoryConcrete(esp0Addr, &esp0, sizeof(esp0))) {
             return -1;
         }
 
         // Based on the "current_stack" function in arch/x86/kernel/irq_32.c
-        target_ulong currentThreadInfo = esp0 & ~(THREAD_SIZE - 1);
+        target_ulong currentThreadInfo = esp0 & ~(linux_common::THREAD_SIZE - 1);
         target_ulong taskStructPtr;
 
         if (!state->mem()->readMemoryConcrete(currentThreadInfo, &taskStructPtr, sizeof(taskStructPtr))) {
@@ -148,7 +162,7 @@ protected:
         s2e_assert(state, ok, "Failed to read instruction memory");
 
         // Validate the instruction's version
-        if (cmd.version != m_commandVersion) {
+        if (cmd.version != CmdVersion) {
             std::ostringstream os;
 
             for (unsigned i = 0; i < sizeof(cmd); ++i) {
@@ -157,8 +171,7 @@ protected:
 
             getWarningsStream(state) << "Command bytes: " << os.str() << "\n";
 
-            s2e_assert(state, false, "Invalid command version " << hexval(cmd.version)
-                                                                << " != " << hexval(m_commandVersion)
+            s2e_assert(state, false, "Invalid command version " << hexval(cmd.version) << " != " << hexval(CmdVersion)
                                                                 << " from pagedir=" << hexval(state->getPageDir())
                                                                 << " pc=" << hexval(state->getPc()));
         }
@@ -168,38 +181,27 @@ protected:
 
 public:
     /// Emitted when one of the custom instructions is executed in the kernel
-    sigc::signal<void, S2EExecutionState *, const CmdT &,
-                 bool // done
-                 >
-        onCustomInstruction;
+    sigc::signal<void, S2EExecutionState *, const CmdT &, bool /* done */> onCustomInstruction;
 
     /// Emitted when a segment fault occurs in the kernel
-    sigc::signal<void, S2EExecutionState *,
-                 uint64_t, // pid
-                 uint64_t  // pc
-                 >
-        onSegFault;
+    sigc::signal<void, S2EExecutionState *, uint64_t, /* pid */ uint64_t /* pc */> onSegFault;
 
     ///
     /// Create a new monitor for the Linux kernel
     ///
     /// \param s2e The global S2E object
-    /// \param startAddr The kernel's start address
-    /// \param stackSize Size of the stack
-    /// \param cmdVer The command identifier emitted from the kernel when an event occurs
     ///
-    BaseLinuxMonitor(S2E *s2e, uint64_t startAddr, unsigned stackSize, uint64_t cmdVer)
-        : OSMonitor(s2e), m_kernelStartAddress(startAddr), m_stackSize(stackSize), m_commandVersion(cmdVer) {
+    BaseLinuxMonitor(S2E *s2e) : OSMonitor(s2e) {
     }
 
     /// Returns \c true if the given program counter is located within the kernel
     virtual bool isKernelAddress(uint64_t pc) const {
-        return pc >= m_kernelStartAddress;
+        return pc >= linux_common::KERNEL_START_ADDRESS;
     }
 
     /// Get the page directory
     virtual uint64_t getAddressSpace(S2EExecutionState *state, uint64_t pc) {
-        if (pc >= m_kernelStartAddress) {
+        if (pc >= linux_common::KERNEL_START_ADDRESS) {
             return 0;
         } else {
             return state->getPageDir();
@@ -216,8 +218,8 @@ public:
             return false;
         }
 
-        *base = module->StackTop - m_stackSize;
-        *size = m_stackSize;
+        *base = module->StackTop - linux_common::STACK_SIZE;
+        *size = linux_common::STACK_SIZE;
 
         // 'pop' instruction can be executed when ESP is set to STACK_TOP
         *size += state->getPointerSize() + 1;

--- a/src/s2e/Plugins/OSMonitors/Linux/DecreeMonitor.h
+++ b/src/s2e/Plugins/OSMonitors/Linux/DecreeMonitor.h
@@ -100,13 +100,14 @@ template <typename T> T &operator<<(T &stream, const S2E_DECREEMON_COMMANDS &c) 
     return stream;
 }
 
-class DecreeMonitor : public BaseLinuxMonitor<S2E_DECREEMON_COMMAND> {
+class DecreeMonitor : public BaseLinuxMonitor<S2E_DECREEMON_COMMAND, S2E_DECREEMON_COMMAND_VERSION> {
     S2E_PLUGIN
 
     friend class DecreeMonitorState;
 
 public:
-    DecreeMonitor(S2E *s2e);
+    DecreeMonitor(S2E *s2e) : BaseLinuxMonitor(s2e) {
+    }
 
     void initialize();
 

--- a/src/s2e/Plugins/OSMonitors/Linux/LinuxMonitor.h
+++ b/src/s2e/Plugins/OSMonitors/Linux/LinuxMonitor.h
@@ -46,12 +46,13 @@ template <typename T> T &operator<<(T &stream, const S2E_LINUXMON_COMMANDS &c) {
 /// Linux 4.9.3 kernel, which can be accessed at
 /// https://github.com/S2E/s2e-linux-kernel.git in the linux-4.9.3 branch.
 ///
-class LinuxMonitor : public BaseLinuxMonitor<S2E_LINUXMON_COMMAND> {
+class LinuxMonitor : public BaseLinuxMonitor<S2E_LINUXMON_COMMAND, S2E_LINUXMON_COMMAND_VERSION> {
     S2E_PLUGIN
 public:
-    // Initialize the plugin
-    LinuxMonitor(S2E *s2e);
-    virtual void initialize();
+    LinuxMonitor(S2E *s2e) : BaseLinuxMonitor(s2e) {
+    }
+
+    void initialize();
 
 private:
     /// Terminate if a trap (e.g. divide by zero) occurs
@@ -70,11 +71,9 @@ private:
 
 public:
     /// Emitted when a trap occurs in the kernel (e.g. divide by zero, etc.)
-    sigc::signal<void, S2EExecutionState *,
-                 uint64_t, // pid
-                 uint64_t, // pc
-                 int       // trapnr
-                 >
+    sigc::signal<void, S2EExecutionState *, uint64_t, /* pid */
+                 uint64_t,                            /* pc */
+                 int /* trapnr */>
         onTrap;
 
     // Get the current process identifier

--- a/src/s2e/Plugins/OSMonitors/Support/ModuleExecutionDetector.cpp
+++ b/src/s2e/Plugins/OSMonitors/Support/ModuleExecutionDetector.cpp
@@ -151,18 +151,18 @@ bool ModuleExecutionDetector::opAddModuleConfigEntry(S2EExecutionState *state) {
     ok &= state->readCpuRegisterConcrete(CPU_OFFSET(regs[R_EDX]), &isKernelMode, sizeof(isKernelMode));
 
     if (!ok) {
-        getWarningsStream(state) << "ModuleExecutionDetector: Could not read parameters.\n";
+        getWarningsStream(state) << "Could not read parameters\n";
         return false;
     }
 
     std::string strModuleId, strModuleName;
     if (!state->mem()->readString(moduleId, strModuleId)) {
-        getWarningsStream(state) << "ModuleExecutionDetector: Could not read the module id string.\n";
+        getWarningsStream(state) << "Could not read the module id string\n";
         return false;
     }
 
     if (!state->mem()->readString(moduleName, strModuleName)) {
-        getWarningsStream(state) << "ModuleExecutionDetector: Could not read the module name string.\n";
+        getWarningsStream(state) << "Could not read the module name string\n";
         return false;
     }
 
@@ -274,10 +274,9 @@ void ModuleExecutionDetector::moduleLoadListener(S2EExecutionState *state, const
     DECLARE_PLUGINSTATE(ModuleTransitionState, state);
 
     // If module name matches the configured ones, activate.
-    getDebugStream() << "ModuleExecutionDetector: "
-                     << "Module " << module.Name << " loaded - "
-                     << "Base=" << hexval(module.LoadBase) << " NativeBase=" << hexval(module.NativeBase)
-                     << " Size=" << hexval(module.Size) << " AS=" << hexval(module.AddressSpace) << "\n";
+    getDebugStream(state) << "Module " << module.Name << " loaded - "
+                          << "Base=" << hexval(module.LoadBase) << " NativeBase=" << hexval(module.NativeBase)
+                          << " Size=" << hexval(module.Size) << " AS=" << hexval(module.AddressSpace) << "\n";
 
     ModuleExecutionCfg cfg;
     cfg.moduleName = module.Name;
@@ -286,7 +285,7 @@ void ModuleExecutionDetector::moduleLoadListener(S2EExecutionState *state, const
         if (plgState->exists(&module, true)) {
             getWarningsStream(state) << " [ALREADY REGISTERED] " << module.Name << "\n";
         } else {
-            getDebugStream() << " [REGISTERING]" << '\n';
+            getDebugStream(state) << " [REGISTERING]\n";
             plgState->loadDescriptor(module, true);
             onModuleLoad.emit(state, module);
         }
@@ -296,20 +295,20 @@ void ModuleExecutionDetector::moduleLoadListener(S2EExecutionState *state, const
     ConfiguredModulesByName::iterator it = m_ConfiguredModulesName.find(cfg);
     if (it != m_ConfiguredModulesName.end()) {
         if (plgState->exists(&module, true)) {
-            getDebugStream() << " [ALREADY REGISTERED ID=" << (*it).id << "]" << '\n';
+            getDebugStream(state) << " [ALREADY REGISTERED ID=" << it->id << "]" << '\n';
         } else {
-            getDebugStream() << " [REGISTERING ID=" << (*it).id << "]" << '\n';
+            getDebugStream(state) << " [REGISTERING ID=" << it->id << "]" << '\n';
             plgState->loadDescriptor(module, true);
             onModuleLoad.emit(state, module);
         }
         return;
     }
 
-    getDebugStream() << '\n';
+    getDebugStream(state) << '\n';
 
     if (m_TrackAllModules) {
         if (!plgState->exists(&module, false)) {
-            getDebugStream() << " [REGISTERING NOT TRACKED]" << '\n';
+            getDebugStream(state) << " [REGISTERING NOT TRACKED]" << '\n';
             plgState->loadDescriptor(module, false);
             onModuleLoad.emit(state, module);
         }
@@ -320,7 +319,7 @@ void ModuleExecutionDetector::moduleLoadListener(S2EExecutionState *state, const
 void ModuleExecutionDetector::moduleUnloadListener(S2EExecutionState *state, const ModuleDescriptor &module) {
     DECLARE_PLUGINSTATE(ModuleTransitionState, state);
 
-    getDebugStream() << "Module " << module.Name << " is unloaded" << '\n';
+    getDebugStream(state) << "Module " << module.Name << " is unloaded" << '\n';
 
     plgState->unloadDescriptor(module);
 }
@@ -328,7 +327,7 @@ void ModuleExecutionDetector::moduleUnloadListener(S2EExecutionState *state, con
 void ModuleExecutionDetector::processUnloadListener(S2EExecutionState *state, uint64_t addressSpace, uint64_t pid) {
     DECLARE_PLUGINSTATE(ModuleTransitionState, state);
 
-    getDebugStream() << "Process " << hexval(addressSpace) << " is unloaded\n";
+    getDebugStream(state) << "Process " << hexval(addressSpace) << " is unloaded\n";
 
     plgState->unloadDescriptorsWithAddressSpace(addressSpace);
 }
@@ -378,10 +377,10 @@ const std::string *ModuleExecutionDetector::getModuleId(const ModuleDescriptor &
     }
 
     if (index) {
-        *index = (*it).index;
+        *index = it->index;
     }
 
-    return &(*it).id;
+    return &(it->id);
 }
 
 std::vector<const ModuleDescriptor *> ModuleExecutionDetector::getModules(S2EExecutionState *state,
@@ -604,7 +603,7 @@ ModuleTransitionState *ModuleTransitionState::clone() const {
 PluginState *ModuleTransitionState::factory(Plugin *p, S2EExecutionState *state) {
     ModuleTransitionState *s = new ModuleTransitionState();
 
-    p->getDebugStream() << "Creating initial module transition state" << '\n';
+    p->getDebugStream() << "Creating initial module transition state\n";
 
     return s;
 }

--- a/src/s2e/Plugins/OSMonitors/Support/ProcessExecutionDetector.cpp
+++ b/src/s2e/Plugins/OSMonitors/Support/ProcessExecutionDetector.cpp
@@ -70,7 +70,7 @@ void ProcessExecutionDetector::onProcessLoad(S2EExecutionState *state, uint64_t 
     if (m_trackedModules.find(ImageFileName) != m_trackedModules.end()) {
         DECLARE_PLUGINSTATE(ProcessExecutionDetectorState, state);
 
-        getDebugStream() << "starting to track: " << ImageFileName << " (pid: " << hexval(pid)
+        getDebugStream(state) << "starting to track: " << ImageFileName << " (pid: " << hexval(pid)
                          << " as: " << hexval(pageDir) << ")\n";
 
         plgState->m_trackedPids.insert(pid);
@@ -79,7 +79,7 @@ void ProcessExecutionDetector::onProcessLoad(S2EExecutionState *state, uint64_t 
 
 void ProcessExecutionDetector::onProcessUnload(S2EExecutionState *state, uint64_t pageDir, uint64_t pid) {
     DECLARE_PLUGINSTATE(ProcessExecutionDetectorState, state);
-    getDebugStream() << "Unloading process " << hexval(pid) << "\n";
+    getDebugStream(state) << "Unloading process " << hexval(pid) << "\n";
     plgState->m_trackedPids.erase(pid);
 }
 


### PR DESCRIPTION
The current offsets were only for the i386 kernel. The x86_64 kernel is now supported.