### PR TITLE
Bugfix/linux task tracking

### DIFF
--- a/src/s2e/Plugins/OSMonitors/Linux/BaseLinuxMonitor.h
+++ b/src/s2e/Plugins/OSMonitors/Linux/BaseLinuxMonitor.h
@@ -89,6 +89,9 @@ protected:
     /// Start address of the Linux kernel
     uint64_t m_kernelStartAddress;
 
+    /// Offset of the process identifier in the \c task_struct struct (see include/linux/sched.h)
+    uint64_t m_taskStructPidOffset;
+
     /// Terminate if a segment fault occurs
     bool m_terminateOnSegfault;
 

--- a/src/s2e/Plugins/OSMonitors/Linux/DecreeMonitor.h
+++ b/src/s2e/Plugins/OSMonitors/Linux/DecreeMonitor.h
@@ -273,6 +273,7 @@ private:
     void handleUpdateMemoryMap(S2EExecutionState *state, uint64_t pid,
                                const S2E_DECREEMON_COMMAND_UPDATE_MEMORY_MAP &d);
     void handleSetParams(S2EExecutionState *state, uint64_t pid, S2E_DECREEMON_COMMAND_SET_CB_PARAMS &d);
+    void handleInit(S2EExecutionState *state, const S2E_DECREEMON_COMMAND_INIT &d);
 };
 
 } // namespace plugins

--- a/src/s2e/Plugins/OSMonitors/Linux/DecreeMonitor.h
+++ b/src/s2e/Plugins/OSMonitors/Linux/DecreeMonitor.h
@@ -100,13 +100,14 @@ template <typename T> T &operator<<(T &stream, const S2E_DECREEMON_COMMANDS &c) 
     return stream;
 }
 
-class DecreeMonitor : public BaseLinuxMonitor<S2E_DECREEMON_COMMAND> {
+class DecreeMonitor : public BaseLinuxMonitor<S2E_DECREEMON_COMMAND, S2E_DECREEMON_COMMAND_VERSION> {
     S2E_PLUGIN
 
     friend class DecreeMonitorState;
 
 public:
-    DecreeMonitor(S2E *s2e);
+    DecreeMonitor(S2E *s2e) : BaseLinuxMonitor(s2e) {
+    }
 
     void initialize();
 
@@ -245,6 +246,8 @@ public:
     static bool isWriteFd(uint32_t fd);
 
 private:
+    target_ulong getTaskStructPtr(S2EExecutionState *state);
+
     uint64_t getMaxValue(S2EExecutionState *state, klee::ref<klee::Expr> value);
     void handleSymbolicSize(S2EExecutionState *state, uint64_t pid, uint64_t safeLimit, klee::ref<klee::Expr> size,
                             uint64_t sizeAddr);

--- a/src/s2e/Plugins/OSMonitors/Linux/LinuxMonitor.h
+++ b/src/s2e/Plugins/OSMonitors/Linux/LinuxMonitor.h
@@ -58,9 +58,6 @@ private:
     /// Address of the \c current_task object in the Linux kernel (see arch/x86/kernel/cpu/common.c)
     uint64_t m_currentTaskAddr;
 
-    /// Offset of the process identifier in the \c task_struct struct (see include/linux/sched.h)
-    uint64_t m_taskStructPidOffset;
-
     /// Offset of the thread group identifier in the \c task_struct struct (see include/linux/sched.h)
     uint64_t m_taskStructTgidOffset;
 

--- a/src/s2e/Plugins/OSMonitors/Support/ModuleExecutionDetector.cpp
+++ b/src/s2e/Plugins/OSMonitors/Support/ModuleExecutionDetector.cpp
@@ -151,18 +151,18 @@ bool ModuleExecutionDetector::opAddModuleConfigEntry(S2EExecutionState *state) {
     ok &= state->readCpuRegisterConcrete(CPU_OFFSET(regs[R_EDX]), &isKernelMode, sizeof(isKernelMode));
 
     if (!ok) {
-        getWarningsStream(state) << "ModuleExecutionDetector: Could not read parameters.\n";
+        getWarningsStream(state) << "Could not read parameters\n";
         return false;
     }
 
     std::string strModuleId, strModuleName;
     if (!state->mem()->readString(moduleId, strModuleId)) {
-        getWarningsStream(state) << "ModuleExecutionDetector: Could not read the module id string.\n";
+        getWarningsStream(state) << "Could not read the module id string\n";
         return false;
     }
 
     if (!state->mem()->readString(moduleName, strModuleName)) {
-        getWarningsStream(state) << "ModuleExecutionDetector: Could not read the module name string.\n";
+        getWarningsStream(state) << "Could not read the module name string\n";
         return false;
     }
 
@@ -274,10 +274,9 @@ void ModuleExecutionDetector::moduleLoadListener(S2EExecutionState *state, const
     DECLARE_PLUGINSTATE(ModuleTransitionState, state);
 
     // If module name matches the configured ones, activate.
-    getDebugStream() << "ModuleExecutionDetector: "
-                     << "Module " << module.Name << " loaded - "
-                     << "Base=" << hexval(module.LoadBase) << " NativeBase=" << hexval(module.NativeBase)
-                     << " Size=" << hexval(module.Size) << " AS=" << hexval(module.AddressSpace) << "\n";
+    getDebugStream(state) << "Module " << module.Name << " loaded - "
+                          << "Base=" << hexval(module.LoadBase) << " NativeBase=" << hexval(module.NativeBase)
+                          << " Size=" << hexval(module.Size) << " AS=" << hexval(module.AddressSpace) << "\n";
 
     ModuleExecutionCfg cfg;
     cfg.moduleName = module.Name;
@@ -286,7 +285,7 @@ void ModuleExecutionDetector::moduleLoadListener(S2EExecutionState *state, const
         if (plgState->exists(&module, true)) {
             getWarningsStream(state) << " [ALREADY REGISTERED] " << module.Name << "\n";
         } else {
-            getDebugStream() << " [REGISTERING]" << '\n';
+            getDebugStream(state) << " [REGISTERING]\n";
             plgState->loadDescriptor(module, true);
             onModuleLoad.emit(state, module);
         }
@@ -296,20 +295,20 @@ void ModuleExecutionDetector::moduleLoadListener(S2EExecutionState *state, const
     ConfiguredModulesByName::iterator it = m_ConfiguredModulesName.find(cfg);
     if (it != m_ConfiguredModulesName.end()) {
         if (plgState->exists(&module, true)) {
-            getDebugStream() << " [ALREADY REGISTERED ID=" << (*it).id << "]" << '\n';
+            getDebugStream(state) << " [ALREADY REGISTERED ID=" << it->id << "]" << '\n';
         } else {
-            getDebugStream() << " [REGISTERING ID=" << (*it).id << "]" << '\n';
+            getDebugStream(state) << " [REGISTERING ID=" << it->id << "]" << '\n';
             plgState->loadDescriptor(module, true);
             onModuleLoad.emit(state, module);
         }
         return;
     }
 
-    getDebugStream() << '\n';
+    getDebugStream(state) << '\n';
 
     if (m_TrackAllModules) {
         if (!plgState->exists(&module, false)) {
-            getDebugStream() << " [REGISTERING NOT TRACKED]" << '\n';
+            getDebugStream(state) << " [REGISTERING NOT TRACKED]" << '\n';
             plgState->loadDescriptor(module, false);
             onModuleLoad.emit(state, module);
         }
@@ -320,7 +319,7 @@ void ModuleExecutionDetector::moduleLoadListener(S2EExecutionState *state, const
 void ModuleExecutionDetector::moduleUnloadListener(S2EExecutionState *state, const ModuleDescriptor &module) {
     DECLARE_PLUGINSTATE(ModuleTransitionState, state);
 
-    getDebugStream() << "Module " << module.Name << " is unloaded" << '\n';
+    getDebugStream(state) << "Module " << module.Name << " is unloaded" << '\n';
 
     plgState->unloadDescriptor(module);
 }
@@ -328,7 +327,7 @@ void ModuleExecutionDetector::moduleUnloadListener(S2EExecutionState *state, con
 void ModuleExecutionDetector::processUnloadListener(S2EExecutionState *state, uint64_t addressSpace, uint64_t pid) {
     DECLARE_PLUGINSTATE(ModuleTransitionState, state);
 
-    getDebugStream() << "Process " << hexval(addressSpace) << " is unloaded\n";
+    getDebugStream(state) << "Process " << hexval(addressSpace) << " is unloaded\n";
 
     plgState->unloadDescriptorsWithAddressSpace(addressSpace);
 }
@@ -378,10 +377,10 @@ const std::string *ModuleExecutionDetector::getModuleId(const ModuleDescriptor &
     }
 
     if (index) {
-        *index = (*it).index;
+        *index = it->index;
     }
 
-    return &(*it).id;
+    return &(it->id);
 }
 
 std::vector<const ModuleDescriptor *> ModuleExecutionDetector::getModules(S2EExecutionState *state,
@@ -604,7 +603,7 @@ ModuleTransitionState *ModuleTransitionState::clone() const {
 PluginState *ModuleTransitionState::factory(Plugin *p, S2EExecutionState *state) {
     ModuleTransitionState *s = new ModuleTransitionState();
 
-    p->getDebugStream() << "Creating initial module transition state" << '\n';
+    p->getDebugStream() << "Creating initial module transition state\n";
 
     return s;
 }

--- a/src/s2e/Plugins/OSMonitors/Support/ProcessExecutionDetector.cpp
+++ b/src/s2e/Plugins/OSMonitors/Support/ProcessExecutionDetector.cpp
@@ -70,8 +70,8 @@ void ProcessExecutionDetector::onProcessLoad(S2EExecutionState *state, uint64_t 
     if (m_trackedModules.find(ImageFileName) != m_trackedModules.end()) {
         DECLARE_PLUGINSTATE(ProcessExecutionDetectorState, state);
 
-        getDebugStream() << "starting to track: " << ImageFileName << " (pid: " << hexval(pid)
-                         << " as: " << hexval(pageDir) << ")\n";
+        getDebugStream(state) << "starting to track: " << ImageFileName << " (pid: " << hexval(pid)
+                              << " as: " << hexval(pageDir) << ")\n";
 
         plgState->m_trackedPids.insert(pid);
     }
@@ -79,7 +79,7 @@ void ProcessExecutionDetector::onProcessLoad(S2EExecutionState *state, uint64_t 
 
 void ProcessExecutionDetector::onProcessUnload(S2EExecutionState *state, uint64_t pageDir, uint64_t pid) {
     DECLARE_PLUGINSTATE(ProcessExecutionDetectorState, state);
-    getDebugStream() << "Unloading process " << hexval(pid) << "\n";
+    getDebugStream(state) << "Unloading process " << hexval(pid) << "\n";
     plgState->m_trackedPids.erase(pid);
 }
 


### PR DESCRIPTION
This fixes an important bug with `LinuxMonitor::getPid`.

The current implementation of `getPid` uses the TSS and `current_thread_info` objects to get a pointer to the current `task_struct`, from which we can read the PID from. Unfortunately, this method is no longer valid for kernel versions > 4.x

This required a lot of refactoring in the S2E Linux kernel. However, it now removes the hardcoded struct offsets from the plugin and makes it usable across multiple architectures and kernel versions.