### PR TITLE
lua: upgrade to 5.3

### DIFF
--- a/src/s2e/Plugins/Lua/LuaS2EExecutionState.cpp
+++ b/src/s2e/Plugins/Lua/LuaS2EExecutionState.cpp
@@ -40,7 +40,7 @@ int LuaS2EExecutionState::regs(lua_State *L) {
 
 int LuaS2EExecutionState::createSymbolicValue(lua_State *L) {
     std::string name = luaL_checkstring(L, 1);
-    uint64_t size = luaL_checklong(L, 2);
+    long size = (long) luaL_checkinteger(L, 2);
 
     assert(size <= 8);
 
@@ -61,7 +61,7 @@ int LuaS2EExecutionState::createSymbolicValue(lua_State *L) {
 }
 
 int LuaS2EExecutionState::kill(lua_State *L) {
-    uint64_t status = luaL_checklong(L, 1);
+    long status = (long) luaL_checkinteger(L, 1);
     std::string message = luaL_checkstring(L, 2);
 
     std::stringstream ss;

--- a/src/s2e/Plugins/Lua/LuaS2EExecutionStateMemory.cpp
+++ b/src/s2e/Plugins/Lua/LuaS2EExecutionStateMemory.cpp
@@ -21,7 +21,7 @@ Lunar<LuaS2EExecutionStateMemory>::RegType LuaS2EExecutionStateMemory::methods[]
     {0, 0}};
 
 int LuaS2EExecutionStateMemory::readPointer(lua_State *L) {
-    uint64_t value = luaL_checklong(L, 1);
+    long value = (long) luaL_checkinteger(L, 1);
 
     uint64_t pointerSize = m_state->getPointerSize();
     if (pointerSize == 4) {
@@ -38,7 +38,7 @@ int LuaS2EExecutionStateMemory::readPointer(lua_State *L) {
 }
 
 int LuaS2EExecutionStateMemory::write(lua_State *L) {
-    uint64_t pointer = luaL_checklong(L, 1);
+    long pointer = (long) luaL_checkinteger(L, 1);
     void *expr = luaL_checkudata(L, 2, "LuaExpression");
 
     LuaExpression *value = *static_cast<LuaExpression **>(expr);

--- a/src/s2e/Plugins/Lua/LuaS2EExecutionStateRegisters.cpp
+++ b/src/s2e/Plugins/Lua/LuaS2EExecutionStateRegisters.cpp
@@ -27,8 +27,8 @@ int LuaS2EExecutionStateRegisters::getPc(lua_State *L) {
 }
 
 int LuaS2EExecutionStateRegisters::read(lua_State *L) {
-    uint64_t pointer = luaL_checklong(L, 1);
-    uint64_t size = luaL_checklong(L, 2);
+    long pointer = (long) luaL_checkinteger(L, 1);
+    long size = (long) luaL_checkinteger(L, 2);
     uint64_t value = 0;
 
     switch (size) {
@@ -58,7 +58,7 @@ int LuaS2EExecutionStateRegisters::read(lua_State *L) {
 }
 
 int LuaS2EExecutionStateRegisters::write(lua_State *L) {
-    uint64_t pointer = luaL_checklong(L, 1);
+    long pointer = (long) luaL_checkinteger(L, 1);
 
     if (lua_isuserdata(L, 2)) {
         void *expr = luaL_checkudata(L, 2, "LuaExpression");
@@ -66,8 +66,8 @@ int LuaS2EExecutionStateRegisters::write(lua_State *L) {
         g_s2e->getDebugStream(m_state) << "Writing " << value->get() << "\n";
         m_state->regs()->write(pointer, value->get());
     } else if (lua_isnumber(L, 2)) {
-        uint64_t value = luaL_checklong(L, 2);
-        uint64_t size = luaL_checklong(L, 3);
+        long value = (long) luaL_checkinteger(L, 2);
+        long size = (long) luaL_checkinteger(L, 3);
         switch (size) {
             case 1:
                 m_state->regs()->write<uint8_t>(pointer, value);


### PR DESCRIPTION
I know that we wanted to phase out Lua, but in the interim there's some stuff I want to do with Lua and I'd rather do it with 5.3 than 5.2 (that is 2 years old now).

I've tested both the `cat` tutorial and `CADET_00001` demo and they both function correctly.

Goes with https://github.com/S2E/build-scripts/pull/13