### PR TITLE
StaticFunctionModels: added missing models

### DIFF
--- a/src/s2e/Plugins/Models/BaseFunctionModels.cpp
+++ b/src/s2e/Plugins/Models/BaseFunctionModels.cpp
@@ -519,6 +519,14 @@ bool BaseFunctionModels::memcpyHelper(S2EExecutionState *state, const uint64_t m
 ///
 bool BaseFunctionModels::strcatHelper(S2EExecutionState *state, const uint64_t strAddrs[2], ref<Expr> &retExpr,
                                       uint64_t numBytes, bool isNcat) {
+    getDebugStream(state) << "Handling str" << (isNcat ? "n" : "") << "cat(" << hexval(strAddrs[0]) << ", "
+                          << hexval(strAddrs[1]);
+    if (isNcat) {
+        getDebugStream(state) << ", " << numBytes << ")\n";
+    } else {
+        getDebugStream(state) << ")\n";
+    }
+
     size_t srcStrLen, destStrLen;
     ref<Expr> srcExprLen, dstExprLen;
 

--- a/src/s2e/Plugins/Models/FunctionModels.cpp
+++ b/src/s2e/Plugins/Models/FunctionModels.cpp
@@ -142,9 +142,7 @@ void FunctionModels::handleStrcat(S2EExecutionState *state, S2E_LIBCWRAPPER_COMM
     stringAddrs[0] = (uint64_t) cmd.Strcat.dst;
     stringAddrs[1] = (uint64_t) cmd.Strcat.src;
 
-    getDebugStream(state) << "Handling strcat(" << hexval(stringAddrs[0]) << ", " << hexval(stringAddrs[1]) << ")\n";
-
-    // Assemble the string concatination expression. We don't use the return expression here because it is just a
+    // Assemble the string concatenation expression. We don't use the return expression here because it is just a
     // concrete address
     ref<Expr> retExpr;
     if (strcatHelper(state, stringAddrs, retExpr)) {
@@ -152,8 +150,6 @@ void FunctionModels::handleStrcat(S2EExecutionState *state, S2E_LIBCWRAPPER_COMM
     } else {
         cmd.needOrigFunc = 1;
     }
-
-    return;
 }
 
 void FunctionModels::handleStrncat(S2EExecutionState *state, S2E_LIBCWRAPPER_COMMAND &cmd) {
@@ -163,10 +159,7 @@ void FunctionModels::handleStrncat(S2EExecutionState *state, S2E_LIBCWRAPPER_COM
     stringAddrs[1] = (uint64_t) cmd.Strncat.src;
     uint64_t numBytes = (int) cmd.Strncat.n;
 
-    getDebugStream(state) << "Handling strncat(" << hexval(stringAddrs[0]) << ", " << hexval(stringAddrs[1]) << ", "
-                          << numBytes << ")\n";
-
-    // Assemble the string concatination expression. We don't use the return expression here because it is just a
+    // Assemble the string concatenation expression. We don't use the return expression here because it is just a
     // concrete address
     ref<Expr> retExpr;
     if (strcatHelper(state, stringAddrs, retExpr, true, numBytes)) {
@@ -174,8 +167,6 @@ void FunctionModels::handleStrncat(S2EExecutionState *state, S2E_LIBCWRAPPER_COM
     } else {
         cmd.needOrigFunc = 1;
     }
-
-    return;
 }
 
 void FunctionModels::handleCrc(S2EExecutionState *state, S2E_LIBCWRAPPER_COMMAND &cmd, ref<Expr> &ret) {

--- a/src/s2e/Plugins/Models/StaticFunctionModels.cpp
+++ b/src/s2e/Plugins/Models/StaticFunctionModels.cpp
@@ -356,52 +356,66 @@ bool StaticFunctionModels::handleStrncat(S2EExecutionState *state, uint64_t pc) 
 }
 
 bool StaticFunctionModels::handleCrc16(S2EExecutionState *state, uint64_t pc) {
-    uint64_t address;
-    if (!readArgument(state, 0, address)) {
-        getWarningsStream(state) << "crc16: could not read address\n";
+    uint64_t initialCrc;
+    if (!readArgument(state, 0, initialCrc)) {
+        getWarningsStream(state) << "crc16: could not read initial crc\n";
         return false;
     }
 
-    uint64_t count;
-    if (!readArgument(state, 1, count)) {
-        getWarningsStream(state) << "crc16: could not read count\n";
+    uint64_t dataAddr;
+    if (!readArgument(state, 1, dataAddr)) {
+        getWarningsStream(state) << "crc16: could not read data address\n";
+        return false;
+    }
+
+    uint64_t len;
+    if (!readArgument(state, 2, len)) {
+        getWarningsStream(state) << "crc16: could not read len\n";
         return false;
     }
 
     std::vector<ref<Expr>> data;
-    if (!readMemory(state, data, address, count)) {
+    if (!readMemory(state, data, dataAddr, len)) {
         getWarningsStream(state) << "crc16: could not read data\n";
         return false;
     }
 
-    ref<Expr> initialCrc = E_CONST(0, Expr::Int16);
-    ref<Expr> crc = crc16(initialCrc, data);
+    getDebugStream(state) << "Handling crc16(" << initialCrc << ", " << hexval(dataAddr) << ", " << len << ")\n";
+
+    ref<Expr> crc = crc16(E_CONST(initialCrc, Expr::Int16), data);
     state->regs()->write(offsetof(CPUX86State, regs[R_EAX]), crc);
 
     return true;
 }
 
 bool StaticFunctionModels::handleCrc32(S2EExecutionState *state, uint64_t pc) {
-    uint64_t address;
-    if (!readArgument(state, 0, address)) {
-        getWarningsStream(state) << "crc32: could not read address\n";
+    uint64_t initialCrc;
+    if (!readArgument(state, 0, initialCrc)) {
+        getWarningsStream(state) << "crc32: could not read initial crc\n";
         return false;
     }
 
-    uint64_t count;
-    if (!readArgument(state, 1, count)) {
-        getWarningsStream(state) << "crc32: could not read count\n";
+    uint64_t dataAddr;
+    if (!readArgument(state, 1, dataAddr)) {
+        getWarningsStream(state) << "crc32: could not read data address\n";
+        return false;
+    }
+
+    uint64_t len;
+    if (!readArgument(state, 2, len)) {
+        getWarningsStream(state) << "crc32: could not read len\n";
         return false;
     }
 
     std::vector<ref<Expr>> data;
-    if (!readMemory(state, data, address, count)) {
+    if (!readMemory(state, data, dataAddr, len)) {
         getWarningsStream(state) << "crc32: could not read data\n";
         return false;
     }
 
-    ref<Expr> initialCrc = E_CONST(0, Expr::Int32);
-    ref<Expr> crc = crc32(initialCrc, data, getBool(state, "xor_result"));
+    getDebugStream(state) << "Handling crc32(" << initialCrc << ", " << hexval(dataAddr) << ", " << len << ")\n";
+
+    ref<Expr> crc = crc32(E_CONST(initialCrc, Expr::Int32), data, getBool(state, "xor_result"));
     state->regs()->write(offsetof(CPUX86State, regs[R_EAX]), crc);
 
     return true;

--- a/src/s2e/Plugins/Models/StaticFunctionModels.h
+++ b/src/s2e/Plugins/Models/StaticFunctionModels.h
@@ -57,8 +57,12 @@ private:
     bool handleStrlen(S2EExecutionState *state, uint64_t pc);
     bool handleStrcmp(S2EExecutionState *state, uint64_t pc);
     bool handleStrncmp(S2EExecutionState *state, uint64_t pc);
+    bool handleStrcpy(S2EExecutionState *state, uint64_t pc);
+    bool handleStrncpy(S2EExecutionState *state, uint64_t pc);
+    bool handleMemcpy(S2EExecutionState *state, uint64_t pc);
     bool handleMemcmp(S2EExecutionState *state, uint64_t pc);
-
+    bool handleStrcat(S2EExecutionState *state, uint64_t pc);
+    bool handleStrncat(S2EExecutionState *state, uint64_t pc);
     bool handleCrc16(S2EExecutionState *state, uint64_t pc);
     bool handleCrc32(S2EExecutionState *state, uint64_t pc);
 


### PR DESCRIPTION
`StaticFunctionModels` was missing a bunch of models. I'm not sure if there is a specific reason for this or it was just an oversight. Either way, I updated the models anyway.