### PR TITLE
Misc. plugin cleanups and fixes

### DIFF
--- a/src/s2e/Plugins/Analyzers/CacheSim.cpp
+++ b/src/s2e/Plugins/Analyzers/CacheSim.cpp
@@ -333,8 +333,8 @@ void CacheSim::initialize() {
 
     ConfigFile *conf = s2e()->getConfig();
 
-    m_execDetector = (ModuleExecutionDetector *) s2e()->getPlugin("ModuleExecutionDetector");
-    m_Tracer = (ExecutionTracer *) s2e()->getPlugin("ExecutionTracer");
+    m_execDetector = s2e()->getPlugin<ModuleExecutionDetector>();
+    m_Tracer = s2e()->getPlugin<ExecutionTracer>();
 
     if (!m_execDetector) {
         getInfoStream() << "ModuleExecutionDetector not found, will profile the whole system" << '\n';

--- a/src/s2e/Plugins/Coverage/BasicBlockCoverage.cpp
+++ b/src/s2e/Plugins/Coverage/BasicBlockCoverage.cpp
@@ -45,8 +45,8 @@ struct BasicBlockCoverageState : public PluginState {
 }
 
 void BasicBlockCoverage::initialize() {
-    m_detector = static_cast<ModuleExecutionDetector *>(s2e()->getPlugin("ModuleExecutionDetector"));
-    m_cfg = static_cast<ControlFlowGraph *>(s2e()->getPlugin("ControlFlowGraph"));
+    m_detector = s2e()->getPlugin<ModuleExecutionDetector>();
+    m_cfg = s2e()->getPlugin<ControlFlowGraph>();
 
     m_detector->onModuleTranslateBlockComplete.connect(
         sigc::mem_fun(*this, &BasicBlockCoverage::onModuleTranslateBlockComplete));

--- a/src/s2e/Plugins/Coverage/TranslationBlockCoverage.cpp
+++ b/src/s2e/Plugins/Coverage/TranslationBlockCoverage.cpp
@@ -42,7 +42,7 @@ struct TBCoverageState : public PluginState {
 }
 
 void TranslationBlockCoverage::initialize() {
-    m_detector = static_cast<ModuleExecutionDetector *>(s2e()->getPlugin("ModuleExecutionDetector"));
+    m_detector = s2e()->getPlugin<ModuleExecutionDetector>();
 
     auto cfg = s2e()->getConfig();
 

--- a/src/s2e/Plugins/ExecutionMonitors/FunctionMonitor.cpp
+++ b/src/s2e/Plugins/ExecutionMonitors/FunctionMonitor.cpp
@@ -24,7 +24,7 @@ S2E_DEFINE_PLUGIN(FunctionMonitor, "Function calls/returns monitoring plugin", "
 
 void FunctionMonitor::initialize() {
     m_monitor = static_cast<OSMonitor *>(s2e()->getPlugin("OSMonitor"));
-    m_detector = static_cast<ModuleExecutionDetector *>(s2e()->getPlugin("ModuleExecutionDetector"));
+    m_detector = s2e()->getPlugin<ModuleExecutionDetector>();
 
     m_localCalls = s2e()->getConfig()->getBool(getConfigKey() + ".monitorLocalFunctions");
 

--- a/src/s2e/Plugins/ExecutionMonitors/FunctionMonitor2.h
+++ b/src/s2e/Plugins/ExecutionMonitors/FunctionMonitor2.h
@@ -10,39 +10,36 @@
 
 #include <s2e/CorePlugin.h>
 #include <s2e/Plugin.h>
-#include <s2e/S2EExecutionState.h>
-
-#include <s2e/Plugins/ExecutionTracers/TranslationBlockTracer.h>
-#include <s2e/Plugins/OSMonitors/Support/ModuleMap.h>
-#include <s2e/Plugins/OSMonitors/Support/ProcessExecutionDetector.h>
-
-#include <llvm/ADT/SmallVector.h>
 
 namespace s2e {
+
+class S2EExecutionState;
+
 namespace plugins {
 
+class ModuleMap;
 class OSMonitor;
+class ProcessExecutionDetector;
 
 class FunctionMonitor2 : public Plugin {
     S2E_PLUGIN
+
 public:
     FunctionMonitor2(S2E *s2e) : Plugin(s2e) {
     }
 
     void initialize();
 
-    sigc::signal<void, S2EExecutionState *, const ModuleDescriptor * /* callerModule */,
-                 const ModuleDescriptor * /* calleeModule */, uint64_t /* callerPc */, uint64_t /* calleePc */>
+    sigc::signal<void, S2EExecutionState *, const ModuleDescriptor * /* caller module */,
+                 const ModuleDescriptor * /* callee module */, uint64_t /* caller PC */, uint64_t /* callee PC */>
         onCall;
 
 private:
     OSMonitor *m_monitor;
     ProcessExecutionDetector *m_processDetector;
     ModuleMap *m_map;
-    ExecutionTracer *m_tracer;
 
-    void onExecuteStart(S2EExecutionState *state, uint64_t pc);
-
+    void onFunctionCall(S2EExecutionState *state, uint64_t pc);
     void onTranslateBlockEnd(ExecutionSignal *signal, S2EExecutionState *state, TranslationBlock *tb, uint64_t pc,
                              bool isStatic, uint64_t staticTarget);
 };

--- a/src/s2e/Plugins/ExecutionMonitors/StackClustering.cpp
+++ b/src/s2e/Plugins/ExecutionMonitors/StackClustering.cpp
@@ -23,10 +23,10 @@ S2E_DEFINE_PLUGIN(StackClustering, "Aggregates the call stack in all states", ""
                   "ModuleExecutionDetector", "ControlFlowGraph", "OSMonitor");
 
 void StackClustering::initialize() {
-    m_stackMonitor = static_cast<StackMonitor *>(s2e()->getPlugin("StackMonitor"));
-    m_detector = static_cast<ModuleExecutionDetector *>(s2e()->getPlugin("ModuleExecutionDetector"));
+    m_stackMonitor = s2e()->getPlugin<StackMonitor>();
+    m_detector = s2e()->getPlugin<ModuleExecutionDetector>();
     m_monitor = static_cast<OSMonitor *>(s2e()->getPlugin("OSMonitor"));
-    m_cfg = static_cast<ControlFlowGraph *>(s2e()->getPlugin("ControlFlowGraph"));
+    m_cfg = s2e()->getPlugin<ControlFlowGraph>();
 
     s2e()->getCorePlugin()->onStateFork.connect(sigc::mem_fun(*this, &StackClustering::onStateFork));
 

--- a/src/s2e/Plugins/ExecutionTracers/EventTracer.cpp
+++ b/src/s2e/Plugins/ExecutionTracers/EventTracer.cpp
@@ -27,10 +27,10 @@ EventTracer::~EventTracer() {
 
 void EventTracer::initialize() {
     // Check that the tracer is there
-    m_Tracer = (ExecutionTracer *) s2e()->getPlugin("ExecutionTracer");
+    m_Tracer = s2e()->getPlugin<ExecutionTracer>();
     assert(m_Tracer);
 
-    m_Detector = (ModuleExecutionDetector *) s2e()->getPlugin("ModuleExecutionDetector");
+    m_Detector = s2e()->getPlugin<ModuleExecutionDetector>();
     assert(m_Detector);
 
     m_TraceAll = false;

--- a/src/s2e/Plugins/ExecutionTracers/ExceptionTracer.cpp
+++ b/src/s2e/Plugins/ExecutionTracers/ExceptionTracer.cpp
@@ -18,7 +18,7 @@ namespace plugins {
 S2E_DEFINE_PLUGIN(ExceptionTracer, "Traces CPU exception", "", "ExecutionTracer");
 
 void ExceptionTracer::initialize() {
-    m_tracer = static_cast<ExecutionTracer *>(s2e()->getPlugin("ExecutionTracer"));
+    m_tracer = s2e()->getPlugin<ExecutionTracer>();
 
     s2e()->getCorePlugin()->onException.connect(sigc::mem_fun(*this, &ExceptionTracer::onException));
 }

--- a/src/s2e/Plugins/ExecutionTracers/ExecutionTracer.cpp
+++ b/src/s2e/Plugins/ExecutionTracers/ExecutionTracer.cpp
@@ -195,7 +195,7 @@ void execution_tracer_flush(void);
 void execution_tracer_flush(void) {
     s2e::plugins::ExecutionTracer *tracer;
 
-    tracer = static_cast<s2e::plugins::ExecutionTracer *>(g_s2e->getPlugin("ExecutionTracer"));
+    tracer = g_s2e->getPlugin<s2e::plugins::ExecutionTracer>();
     if (!tracer) {
         return;
     }

--- a/src/s2e/Plugins/ExecutionTracers/InstructionCounter.cpp
+++ b/src/s2e/Plugins/ExecutionTracers/InstructionCounter.cpp
@@ -29,10 +29,10 @@ S2E_DEFINE_PLUGIN(InstructionCounter, "Instruction counter plugin", "Instruction
 void InstructionCounter::initialize() {
     m_tb = NULL;
 
-    m_executionTracer = static_cast<ExecutionTracer *>(s2e()->getPlugin("ExecutionTracer"));
+    m_executionTracer = s2e()->getPlugin<ExecutionTracer>();
     assert(m_executionTracer);
 
-    m_executionDetector = static_cast<ModuleExecutionDetector *>(s2e()->getPlugin("ModuleExecutionDetector"));
+    m_executionDetector = s2e()->getPlugin<ModuleExecutionDetector>();
     assert(m_executionDetector);
 
     // TODO: whole-system counting

--- a/src/s2e/Plugins/ExecutionTracers/MemoryTracer.cpp
+++ b/src/s2e/Plugins/ExecutionTracers/MemoryTracer.cpp
@@ -32,8 +32,8 @@ MemoryTracer::MemoryTracer(S2E *s2e) : Plugin(s2e) {
 }
 
 void MemoryTracer::initialize() {
-    m_tracer = static_cast<ExecutionTracer *>(s2e()->getPlugin("ExecutionTracer"));
-    m_execDetector = static_cast<ModuleExecutionDetector *>(s2e()->getPlugin("ModuleExecutionDetector"));
+    m_tracer = s2e()->getPlugin<ExecutionTracer>();
+    m_execDetector = s2e()->getPlugin<ModuleExecutionDetector>();
 
     // Retrict monitoring to configured modules only
     m_monitorModules = s2e()->getConfig()->getBool(getConfigKey() + ".monitorModules");

--- a/src/s2e/Plugins/ExecutionTracers/ModuleTracer.cpp
+++ b/src/s2e/Plugins/ExecutionTracers/ModuleTracer.cpp
@@ -32,7 +32,7 @@ ModuleTracer::~ModuleTracer() {
 }
 
 void ModuleTracer::initialize() {
-    m_Tracer = (ExecutionTracer *) s2e()->getPlugin("ExecutionTracer");
+    m_Tracer = s2e()->getPlugin<ExecutionTracer>();
     assert(m_Tracer);
 
     OSMonitor *monitor = (OSMonitor *) s2e()->getPlugin("OSMonitor");

--- a/src/s2e/Plugins/ExecutionTracers/StateSwitchTracer.cpp
+++ b/src/s2e/Plugins/ExecutionTracers/StateSwitchTracer.cpp
@@ -16,7 +16,7 @@ namespace plugins {
 S2E_DEFINE_PLUGIN(StateSwitchTracer, "Traces state switches", "", "ExecutionTracer");
 
 void StateSwitchTracer::initialize() {
-    m_tracer = static_cast<ExecutionTracer *>(s2e()->getPlugin("ExecutionTracer"));
+    m_tracer = s2e()->getPlugin<ExecutionTracer>();
 
     s2e()->getCorePlugin()->onStateSwitch.connect(sigc::mem_fun(*this, &StateSwitchTracer::onStateSwitch));
 }

--- a/src/s2e/Plugins/ExecutionTracers/TBCoverageTracer.cpp
+++ b/src/s2e/Plugins/ExecutionTracers/TBCoverageTracer.cpp
@@ -50,8 +50,8 @@ S2E_DEFINE_PLUGIN(TBCoverageTracer, "Tracer for translation blocks", "TBCoverage
                   "ModuleExecutionDetector");
 
 void TBCoverageTracer::initialize() {
-    m_tracer = (ExecutionTracer *) s2e()->getPlugin("ExecutionTracer");
-    m_detector = (ModuleExecutionDetector *) s2e()->getPlugin("ModuleExecutionDetector");
+    m_tracer = s2e()->getPlugin<ExecutionTracer>();
+    m_detector = s2e()->getPlugin<ModuleExecutionDetector>();
 
     m_manualTrigger = s2e()->getConfig()->getBool(getConfigKey() + ".manualTrigger", false, NULL);
 

--- a/src/s2e/Plugins/ExecutionTracers/TranslationBlockTracer.cpp
+++ b/src/s2e/Plugins/ExecutionTracers/TranslationBlockTracer.cpp
@@ -27,8 +27,8 @@ S2E_DEFINE_PLUGIN(TranslationBlockTracer, "Tracer for executed translation block
                   "ExecutionTracer");
 
 void TranslationBlockTracer::initialize() {
-    m_tracer = (ExecutionTracer *) s2e()->getPlugin("ExecutionTracer");
-    m_detector = (ModuleExecutionDetector *) s2e()->getPlugin("ModuleExecutionDetector");
+    m_tracer = s2e()->getPlugin<ExecutionTracer>();
+    m_detector = s2e()->getPlugin<ModuleExecutionDetector>();
 
     // Retrict monitoring to configured modules only
     m_monitorModules = s2e()->getConfig()->getBool(getConfigKey() + ".monitorModules");

--- a/src/s2e/Plugins/OSMonitors/Linux/BaseLinuxMonitor.h
+++ b/src/s2e/Plugins/OSMonitors/Linux/BaseLinuxMonitor.h
@@ -168,7 +168,7 @@ public:
 
     /// Get the base address and size of the stack
     virtual bool getCurrentStack(S2EExecutionState *state, uint64_t *base, uint64_t *size) {
-        ModuleExecutionDetector *detector = (ModuleExecutionDetector *) s2e()->getPlugin("ModuleExecutionDetector");
+        ModuleExecutionDetector *detector = s2e()->template getPlugin<ModuleExecutionDetector>();
         assert(detector);
 
         const ModuleDescriptor *module = detector->getCurrentDescriptor(state);

--- a/src/s2e/Plugins/OSMonitors/Linux/LinuxMonitor.cpp
+++ b/src/s2e/Plugins/OSMonitors/Linux/LinuxMonitor.cpp
@@ -180,8 +180,6 @@ void LinuxMonitor::handleProcessExit(S2EExecutionState *state, const S2E_LINUXMO
     getDebugStream(state) << "Removing task (pid=" << hexval(cmd.currentPid) << ", cr3=" << hexval(mod->AddressSpace)
                           << ", exitCode=" << cmd.ProcessExit.code << ") record from collector.\n";
     plgState->removeModule(*mod);
-
-    return;
 }
 
 void LinuxMonitor::handleTrap(S2EExecutionState *state, const S2E_LINUXMON_COMMAND &cmd) {

--- a/src/s2e/Plugins/OSMonitors/Support/ModuleExecutionDetector.cpp
+++ b/src/s2e/Plugins/OSMonitors/Support/ModuleExecutionDetector.cpp
@@ -327,9 +327,9 @@ void ModuleExecutionDetector::moduleUnloadListener(S2EExecutionState *state, con
 void ModuleExecutionDetector::processUnloadListener(S2EExecutionState *state, uint64_t addressSpace, uint64_t pid) {
     DECLARE_PLUGINSTATE(ModuleTransitionState, state);
 
-    getDebugStream(state) << "Process " << hexval(addressSpace) << " is unloaded\n";
+    getDebugStream(state) << "Process " << hexval(addressSpace) << " (pid=" << hexval(pid) << ") is unloaded\n";
 
-    plgState->unloadDescriptorsWithAddressSpace(addressSpace);
+    plgState->unloadDescriptor(pid);
 }
 
 // Check that the module id is valid
@@ -491,7 +491,7 @@ const ModuleDescriptor *ModuleExecutionDetector::getCurrentDescriptor(S2EExecuti
     DECLARE_PLUGINSTATE_CONST(ModuleTransitionState, state);
 
     uint64_t pc = state->getPc();
-    uint64_t addressSpace = m_Monitor->getAddressSpace(state, state->getPc());
+    uint64_t addressSpace = m_Monitor->getAddressSpace(state, pc);
 
     return plgState->getDescriptor(addressSpace, pc);
 }
@@ -701,11 +701,11 @@ void ModuleTransitionState::unloadDescriptor(const ModuleDescriptor &desc) {
     }
 }
 
-void ModuleTransitionState::unloadDescriptorsWithAddressSpace(uint64_t addressSpace) {
+void ModuleTransitionState::unloadDescriptor(uint64_t pid) {
     DescriptorSet::iterator it, it1;
 
     for (it = m_Descriptors.begin(); it != m_Descriptors.end();) {
-        if ((*it)->AddressSpace != addressSpace) {
+        if ((*it)->Pid != pid) {
             ++it;
         } else {
             it1 = it;
@@ -729,7 +729,7 @@ void ModuleTransitionState::unloadDescriptorsWithAddressSpace(uint64_t addressSp
 
     // XXX: avoid copy/paste
     for (it = m_NotTrackedDescriptors.begin(); it != m_NotTrackedDescriptors.end();) {
-        if ((*it)->AddressSpace != addressSpace) {
+        if ((*it)->Pid != pid) {
             ++it;
         } else {
             it1 = it;

--- a/src/s2e/Plugins/OSMonitors/Support/ModuleExecutionDetector.h
+++ b/src/s2e/Plugins/OSMonitors/Support/ModuleExecutionDetector.h
@@ -213,7 +213,7 @@ private:
 
     bool loadDescriptor(const ModuleDescriptor &desc, bool track);
     void unloadDescriptor(const ModuleDescriptor &desc);
-    void unloadDescriptorsWithAddressSpace(uint64_t addressSpace);
+    void unloadDescriptor(uint64_t pid);
     bool exists(const ModuleDescriptor *desc, bool tracked) const;
 
 public:

--- a/src/s2e/Plugins/OSMonitors/Windows/WindowsCrashDumpGenerator.cpp
+++ b/src/s2e/Plugins/OSMonitors/Windows/WindowsCrashDumpGenerator.cpp
@@ -124,7 +124,7 @@ WindowsCrashDumpInvoker::WindowsCrashDumpInvoker(WindowsCrashDumpGenerator *plg)
 }
 
 WindowsCrashDumpInvoker::WindowsCrashDumpInvoker(lua_State *lua) {
-    m_plugin = static_cast<WindowsCrashDumpGenerator *>(g_s2e->getPlugin("WindowsCrashDumpGenerator"));
+    m_plugin = g_s2e->getPlugin<WindowsCrashDumpGenerator>();
 }
 
 WindowsCrashDumpInvoker::~WindowsCrashDumpInvoker() {

--- a/src/s2e/Plugins/OSMonitors/Windows/WindowsMonitor.cpp
+++ b/src/s2e/Plugins/OSMonitors/Windows/WindowsMonitor.cpp
@@ -157,10 +157,10 @@ void WindowsMonitor::initialize() {
     m_kernelStart = 0;
 
     // Optional plugins for debugging
-    m_tbTracer = static_cast<TranslationBlockTracer *>(s2e()->getPlugin("TranslationBlockTracer"));
-    m_memTracer = static_cast<MemoryTracer *>(s2e()->getPlugin("MemoryTracer"));
+    m_tbTracer = s2e()->getPlugin<TranslationBlockTracer>();
+    m_memTracer = s2e()->getPlugin<MemoryTracer>();
 
-    m_vmi = static_cast<Vmi *>(s2e()->getPlugin("Vmi"));
+    m_vmi = s2e()->getPlugin<Vmi>();
 
     ConfigFile *cfg = s2e()->getConfig();
     m_debugDpc = cfg->getBool(getConfigKey() + ".debugDpc");

--- a/src/s2e/Plugins/PathLimiters/EdgeKiller.cpp
+++ b/src/s2e/Plugins/PathLimiters/EdgeKiller.cpp
@@ -21,8 +21,8 @@ S2E_DEFINE_PLUGIN(EdgeKiller, "Kills states that encounter a given (start_pc, en
                   "ModuleExecutionDetector");
 
 void EdgeKiller::initialize() {
-    m_detector = static_cast<ModuleExecutionDetector *>(s2e()->getPlugin("ModuleExecutionDetector"));
-    m_edgeDetector = static_cast<EdgeDetector *>(s2e()->getPlugin("EdgeDetector"));
+    m_detector = s2e()->getPlugin<ModuleExecutionDetector>();
+    m_edgeDetector = s2e()->getPlugin<EdgeDetector>();
     m_edgeDetector->readConfig(getConfigKey(), this);
     m_edgeDetector->onEdge.connect(sigc::mem_fun(*this, &EdgeKiller::onEdge));
 }

--- a/src/s2e/Plugins/Searchers/CUPASearcher.cpp
+++ b/src/s2e/Plugins/Searchers/CUPASearcher.cpp
@@ -379,7 +379,7 @@ sigc::connection CUPASearcherReadCountClass::s_read_conn;
 
 CUPASearcherReadCountClass::CUPASearcherReadCountClass(CUPASearcher *plugin, unsigned level)
     : CUPASearcherClass(plugin, level) {
-    m_monitor = static_cast<DecreeMonitor *>(plugin->s2e()->getPlugin("DecreeMonitor"));
+    m_monitor = plugin->s2e()->getPlugin<DecreeMonitor>();
 
     if (!s_read_conn.connected()) {
         s_read_conn = m_monitor->onSymbolicRead.connect(sigc::ptr_fun(&CUPASearcherReadCountClass::onSymbolicRead));

--- a/src/s2e/Plugins/Searchers/LoopExitSearcher.cpp
+++ b/src/s2e/Plugins/Searchers/LoopExitSearcher.cpp
@@ -28,11 +28,11 @@ S2E_DEFINE_PLUGIN(LoopExitSearcher, "Searcher that prioritizes states that exit 
 void LoopExitSearcher::initialize() {
     s2e()->getExecutor()->setSearcher(this);
 
-    m_loopDetector = static_cast<LoopDetector *>(s2e()->getPlugin("LoopDetector"));
-    m_cfg = static_cast<ControlFlowGraph *>(s2e()->getPlugin("ControlFlowGraph"));
-    m_detector = static_cast<ModuleExecutionDetector *>(s2e()->getPlugin("ModuleExecutionDetector"));
-    m_bbcov = static_cast<coverage::BasicBlockCoverage *>(s2e()->getPlugin("BasicBlockCoverage"));
-    m_ecov = static_cast<EdgeCoverage *>(s2e()->getPlugin("EdgeCoverage"));
+    m_loopDetector = s2e()->getPlugin<LoopDetector>();
+    m_cfg = s2e()->getPlugin<ControlFlowGraph>();
+    m_detector = s2e()->getPlugin<ModuleExecutionDetector>();
+    m_bbcov = s2e()->getPlugin<coverage::BasicBlockCoverage>();
+    m_ecov = s2e()->getPlugin<EdgeCoverage>();
 
     s2e()->getCorePlugin()->onStateFork.connect(sigc::mem_fun(*this, &LoopExitSearcher::onFork));
 

--- a/src/s2e/Plugins/StaticAnalysis/ControlFlowGraph.cpp
+++ b/src/s2e/Plugins/StaticAnalysis/ControlFlowGraph.cpp
@@ -22,7 +22,7 @@ namespace plugins {
 S2E_DEFINE_PLUGIN(ControlFlowGraph, "Manages control flow graphs for modules", "", "ModuleExecutionDetector");
 
 void ControlFlowGraph::initialize() {
-    m_detector = static_cast<ModuleExecutionDetector *>(s2e()->getPlugin("ModuleExecutionDetector"));
+    m_detector = s2e()->getPlugin<ModuleExecutionDetector>();
     loadConfiguration();
 
     // This sets up a timer that will periodically check if the lua script

--- a/src/s2e/Plugins/StaticAnalysis/EdgeDetector.cpp
+++ b/src/s2e/Plugins/StaticAnalysis/EdgeDetector.cpp
@@ -27,7 +27,7 @@ S2E_DEFINE_PLUGIN(EdgeDetector, "Fires an event when a specified sequence of ins
                   "EdgeDetector", "ModuleExecutionDetector");
 
 void EdgeDetector::initialize() {
-    m_detector = static_cast<ModuleExecutionDetector *>(s2e()->getPlugin("ModuleExecutionDetector"));
+    m_detector = s2e()->getPlugin<ModuleExecutionDetector>();
 
     readConfig(getConfigKey(), this);
 

--- a/src/s2e/Plugins/StaticAnalysis/LoopDetector.cpp
+++ b/src/s2e/Plugins/StaticAnalysis/LoopDetector.cpp
@@ -21,9 +21,9 @@ S2E_DEFINE_PLUGIN(LoopDetector, "LoopDetector S2E plugin", "", "EdgeDetector", "
                   "ControlFlowGraph");
 
 void LoopDetector::initialize() {
-    m_detector = static_cast<ModuleExecutionDetector *>(s2e()->getPlugin("ModuleExecutionDetector"));
-    m_edgeDetector = static_cast<EdgeDetector *>(s2e()->getPlugin("EdgeDetector"));
-    m_cfg = static_cast<ControlFlowGraph *>(s2e()->getPlugin("ControlFlowGraph"));
+    m_detector = s2e()->getPlugin<ModuleExecutionDetector>();
+    m_edgeDetector = s2e()->getPlugin<EdgeDetector>();
+    m_cfg = s2e()->getPlugin<ControlFlowGraph>();
 
     /**
      * Sample configuration entry:

--- a/src/s2e/Plugins/VulnerabilityAnalysis/Recipe/RecipeDescriptor.cpp
+++ b/src/s2e/Plugins/VulnerabilityAnalysis/Recipe/RecipeDescriptor.cpp
@@ -15,6 +15,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/regex.hpp>
 
+#include "Recipe.h"
 #include "RecipeDescriptor.h"
 
 namespace s2e {
@@ -31,7 +32,7 @@ static Plugin *s_plugin;
 // to that plugin).
 static llvm::raw_ostream &getDebugStream() {
     if (!s_plugin) {
-        s_plugin = g_s2e->getPlugin("Recipe");
+        s_plugin = g_s2e->getPlugin<Recipe>();
     }
 
     return s_plugin->getDebugStream() << "RecipeDescriptor: ";
@@ -39,7 +40,7 @@ static llvm::raw_ostream &getDebugStream() {
 
 static llvm::raw_ostream &getWarningsStream() {
     if (!s_plugin) {
-        s_plugin = g_s2e->getPlugin("Recipe");
+        s_plugin = g_s2e->getPlugin<Recipe>();
     }
 
     return s_plugin->getWarningsStream() << "RecipeDescriptor: ";


### PR DESCRIPTION
## FunctionMonitor2

* removed redundant includes and unused dependencies
* fixed reading source/destination modules (they were exactly the same)
* fixed emitted signal to return the caller PC rather than the return PC
* Ensured that the emitted signal contains the callee PC (call target address)

## LinuxMonitors

* code cleanup
* added `ModuleExecutionDetector` as a dependency, since it is required to get the current stack

## ModuleExecutionDetector

* unload process based on PID. Was previously address space (i.e. page dir), but this was causing problems on Linux

## LibraryCallMonitor

* moved `ProcessExecutionDetector` check to instruction execution (rather than translation) as per Vitaly's advice