### PR TITLE
ProcessExecutionDetector: don't exit if config is empty

### DIFF
--- a/src/s2e/Plugins/OSMonitors/Support/ProcessExecutionDetector.cpp
+++ b/src/s2e/Plugins/OSMonitors/Support/ProcessExecutionDetector.cpp
@@ -53,7 +53,6 @@ void ProcessExecutionDetector::initialize() {
 
     if (moduleList.empty()) {
         getWarningsStream() << "no modules configured\n";
-        exit(-1);
     }
 
     foreach2 (it, moduleList.begin(), moduleList.end()) { m_trackedModules.insert(*it); }


### PR DESCRIPTION
Sometimes there is just no process to monitor (e.g., it testing a driver)

Signed-off-by: Vitaly Chipounov <vitaly@cyberhaven.io>