### PR TITLE
bugfix/process tracking fixes

### DIFF
--- a/src/s2e/Plugins/ExecutionMonitors/LibraryCallMonitor.cpp
+++ b/src/s2e/Plugins/ExecutionMonitors/LibraryCallMonitor.cpp
@@ -65,7 +65,7 @@ void LibraryCallMonitor::onIndirectCallOrJump(S2EExecutionState *state, uint64_t
 
     // Only interested in particular modules loaded in the process
     const ModuleDescriptor *currentMod = m_map->getModule(state, pc);
-    if (!(m_monitorAllModules || (currentMod && m_procDetector->isTracked(currentMod->Name)))) {
+    if (!(m_monitorAllModules || (currentMod && m_procDetector->isTracked(state)))) {
         return;
     }
 

--- a/src/s2e/Plugins/OSMonitors/Support/ProcessExecutionDetector.cpp
+++ b/src/s2e/Plugins/OSMonitors/Support/ProcessExecutionDetector.cpp
@@ -79,8 +79,9 @@ void ProcessExecutionDetector::onProcessLoad(S2EExecutionState *state, uint64_t 
 void ProcessExecutionDetector::onProcessUnload(S2EExecutionState *state, uint64_t pageDir, uint64_t pid,
                                                uint64_t returnCode) {
     DECLARE_PLUGINSTATE(ProcessExecutionDetectorState, state);
-    getDebugStream(state) << "Unloading process " << hexval(pid) << "\n";
-    plgState->m_trackedPids.erase(pid);
+    if (plgState->m_trackedPids.erase(pid)) {
+        getDebugStream(state) << "Unloading process " << hexval(pid) << "\n";
+    }
 }
 
 bool ProcessExecutionDetector::isTracked(S2EExecutionState *state, uint64_t pid) {


### PR DESCRIPTION
`LibraryCallMonitor` uses `ProcessExecutionDetector` and `ModuleMap` to track library calls made in a particular process. However, there is an inconsistency between the module name that `ModuleMap` uses and the process name that `ProcessExecutionDetector` uses, which makes it impossible to track library calls this way. So let's not use the module name!