### PR TITLE
Bugfix/module map export cache

### DIFF
--- a/src/s2e/Plugins/ExecutionMonitors/LibraryCallMonitor.h
+++ b/src/s2e/Plugins/ExecutionMonitors/LibraryCallMonitor.h
@@ -75,7 +75,7 @@ private:
     bool m_monitorIndirectJumps;
 
     void logLibraryCall(S2EExecutionState *state, const std::string &callerMod, uint64_t pc, unsigned sourceType,
-                        const std::string &calleeMod, const std::string &function) const;
+                        const std::string &calleeMod, const std::string &function, uint64_t pid) const;
 
     void onTranslateBlockEnd(ExecutionSignal *signal, S2EExecutionState *state, TranslationBlock *tb, uint64_t pc,
                              bool isStatic, uint64_t staticTarget);

--- a/src/s2e/Plugins/OSMonitors/Support/ModuleMap.cpp
+++ b/src/s2e/Plugins/OSMonitors/Support/ModuleMap.cpp
@@ -78,6 +78,13 @@ private:
     const static size_t MAX_EXPORT_CACHE_SIZE = 50;
 
 public:
+    ModuleMapState() : m_modules(), m_exportCacheList(), m_exportCacheMap() {
+    }
+
+    // Start with an empty cache on state clone
+    ModuleMapState(const ModuleMapState &state) : m_modules(state.m_modules), m_exportCacheList(), m_exportCacheMap() {
+    }
+
     virtual ~ModuleMapState() {
     }
 
@@ -177,14 +184,14 @@ public:
 
     void cacheExport(uint64_t address, const ModuleMap::Export &exp) {
         auto it = m_exportCacheMap.find(address);
-        m_exportCacheList.push_front({address, exp});
 
         if (it != m_exportCacheMap.end()) {
             m_exportCacheList.erase(it->second);
             m_exportCacheMap.erase(it);
         }
 
-        m_exportCacheMap[address] = m_exportCacheList.begin();
+        m_exportCacheList.push_front({address, exp});
+        m_exportCacheMap.insert({address, m_exportCacheList.begin()});
 
         if (m_exportCacheMap.size() > MAX_EXPORT_CACHE_SIZE) {
             auto last = m_exportCacheList.end();


### PR DESCRIPTION
Things were crashing when states forked and you tried to do an export lookup in the new state