### PR TITLE
TestCaseGenerator: Add the generateRaw option

### DIFF
--- a/src/s2e/Plugins/ExecutionTracers/TestCaseGenerator.h
+++ b/src/s2e/Plugins/ExecutionTracers/TestCaseGenerator.h
@@ -53,6 +53,7 @@ public:
 private:
     sigc::connection m_connection;
     ExecutionTracer *m_tracer;
+    bool m_tcRaw;
 
     void onStateKill(S2EExecutionState *state);
     void onSegFault(S2EExecutionState *state, uint64_t pid, uint64_t pc);
@@ -61,6 +62,7 @@ private:
 
     void writeTestCaseToTrace(S2EExecutionState *state, const ConcreteInputs &inputs);
     void writeSimpleTestCase(llvm::raw_ostream &os, const ConcreteInputs &inputs);
+    void writeRawTestCase(S2EExecutionState* state, const std::string &prefix, const ConcreteInputs &inputs);
 
     bool getFilePart(const std::string &variableName, std::string &filePath, unsigned *part, unsigned *total) const;
     void getFiles(const ConcreteInputs &inputs, TestCaseFiles &files);


### PR DESCRIPTION
Currently, TestcaseGenerator only saves testcases from files. However,
users may want to save other testcases to post-process, for example,
stdin or manually defined symbols. .generateRaw option allows users
to save testcases in raw format even though it is not from files.