### PR TITLE
LuaS2EExecutionStateMemory Interface extended

### DIFF
--- a/src/s2e/Plugins/Lua/LuaFunctionAnnotation.cpp
+++ b/src/s2e/Plugins/Lua/LuaFunctionAnnotation.cpp
@@ -162,7 +162,8 @@ void LuaFunctionAnnotation::hookAnnotation(S2EExecutionState *state, const Modul
                                            const Annotation &annotation) {
     uint64_t funcPc = module.ToRuntime(annotation.pc);
 
-    FunctionMonitor::CallSignal *cs = m_functionMonitor->getCallSignal(state, funcPc, m_monitor->getPid(state, funcPc));
+    FunctionMonitor::CallSignal *cs =
+        m_functionMonitor->getCallSignal(state, funcPc, m_monitor->getAddressSpace(state, funcPc));
     cs->connect(sigc::bind(sigc::mem_fun(*this, &LuaFunctionAnnotation::onFunctionCall), annotation));
 }
 
@@ -269,8 +270,7 @@ void LuaFunctionAnnotation::invokeAnnotation(S2EExecutionState *state, const Ann
     }
 }
 
-void LuaFunctionAnnotation::onFunctionCall(S2EExecutionState *state, FunctionMonitorState *fns,
-                                           const Annotation &entry) {
+void LuaFunctionAnnotation::onFunctionCall(S2EExecutionState *state, FunctionMonitorState *fns, Annotation entry) {
     state->undoCallAndJumpToSymbolic();
     getDebugStream() << "Invoking call annotation " << entry.annotationName << '\n';
 
@@ -281,7 +281,7 @@ void LuaFunctionAnnotation::onFunctionCall(S2EExecutionState *state, FunctionMon
     invokeAnnotation(state, entry, true);
 }
 
-void LuaFunctionAnnotation::onFunctionRet(S2EExecutionState *state, const Annotation &entry) {
+void LuaFunctionAnnotation::onFunctionRet(S2EExecutionState *state, Annotation entry) {
     state->jumpToSymbolicCpp();
     getDebugStream() << "Invoking return annotation " << entry.annotationName << '\n';
     invokeAnnotation(state, entry, false);

--- a/src/s2e/Plugins/Lua/LuaFunctionAnnotation.h
+++ b/src/s2e/Plugins/Lua/LuaFunctionAnnotation.h
@@ -68,8 +68,8 @@ private:
     void onModuleLoad(S2EExecutionState *state, const ModuleDescriptor &module);
     void onModuleUnload(S2EExecutionState *state, const ModuleDescriptor &module);
 
-    void onFunctionCall(S2EExecutionState *state, FunctionMonitorState *fns, const Annotation &entry);
-    void onFunctionRet(S2EExecutionState *state, const Annotation &entry);
+    void onFunctionCall(S2EExecutionState *state, FunctionMonitorState *fns, Annotation entry);
+    void onFunctionRet(S2EExecutionState *state, Annotation entry);
 };
 
 } // namespace plugins


### PR DESCRIPTION
I extended the LuaS2EExecutionStateMemory Interface such that one can now also write concrete data into memory using the Lua Plugin and not only symbolic data.