### PR TITLE
TranslationBlockTracer: Fix erroneous comment

### DIFF
--- a/src/s2e/Plugins/ExecutionTracers/TranslationBlockTracer.h
+++ b/src/s2e/Plugins/ExecutionTracers/TranslationBlockTracer.h
@@ -74,4 +74,4 @@ public:
 } // namespace plugins
 } // namespace s2e
 
-#endif // S2E_PLUGINS_EXAMPLE_H
+#endif // S2E_PLUGINS_TBTRACER_H


### PR DESCRIPTION
The ```#endif``` probably wasn't closing the example header. 