### PR TITLE
Added ability to dynamically register LuaInstructionAnnotation

### DIFF
--- a/src/s2e/Plugins/Lua/LuaInstructionAnnotation.cpp
+++ b/src/s2e/Plugins/Lua/LuaInstructionAnnotation.cpp
@@ -87,7 +87,7 @@ bool LuaInstructionAnnotation::registerAnnotation(const std::string &moduleId, c
 
     if (m_annotations[moduleId]->find(annotation) != m_annotations[moduleId]->end()) {
         getWarningsStream() << "attempting to register existing annotation\n";
-        return false;
+        return true;
     }
 
     m_annotations[moduleId]->insert(annotation);

--- a/src/s2e/Plugins/Lua/LuaInstructionAnnotation.h
+++ b/src/s2e/Plugins/Lua/LuaInstructionAnnotation.h
@@ -27,9 +27,6 @@ public:
     LuaInstructionAnnotation(S2E *s2e) : Plugin(s2e) {
     }
 
-    void initialize();
-
-private:
     struct Annotation {
         const std::string annotationName;
         const uint64_t pc;
@@ -49,6 +46,13 @@ private:
         }
     };
 
+    void initialize();
+
+    bool registerAnnotation(const std::string &moduleId, const Annotation &annotation);
+
+private:
+
+
     typedef std::set<Annotation> ModuleAnnotations;
     typedef std::map<std::string, ModuleAnnotations *> Annotations;
     Annotations m_annotations;
@@ -57,7 +61,7 @@ private:
     ModuleMap *m_modules;
     sigc::connection m_instructionStart;
 
-    bool registerAnnotation(const std::string &moduleId, const Annotation &annotation);
+
 
     void onTranslateBlockStart(ExecutionSignal *signal, S2EExecutionState *state, TranslationBlock *tb, uint64_t pc);
 

--- a/src/s2e/Plugins/Lua/LuaS2EExecutionState.cpp
+++ b/src/s2e/Plugins/Lua/LuaS2EExecutionState.cpp
@@ -13,6 +13,8 @@
 #include "LuaS2EExecutionStateMemory.h"
 #include "LuaS2EExecutionStateRegisters.h"
 
+#include "LuaInstructionAnnotation.h"
+
 namespace s2e {
 namespace plugins {
 
@@ -26,6 +28,7 @@ Lunar<LuaS2EExecutionState>::RegType LuaS2EExecutionState::methods[] = {
     LUNAR_DECLARE_METHOD(LuaS2EExecutionState, setPluginProperty),
     LUNAR_DECLARE_METHOD(LuaS2EExecutionState, getPluginProperty),
     LUNAR_DECLARE_METHOD(LuaS2EExecutionState, debug),
+    LUNAR_DECLARE_METHOD(LuaS2EExecutionState, registerInstructionAnnotation),
     {0, 0}};
 
 int LuaS2EExecutionState::mem(lua_State *L) {
@@ -123,6 +126,20 @@ int LuaS2EExecutionState::debug(lua_State *L) {
     g_s2e->getDebugStream(m_state) << str << c;
 
     return 0;
+}
+
+int LuaS2EExecutionState::registerInstructionAnnotation(lua_State *L){
+    std::string moduleId=luaL_checkstring(L, 1);
+    std::string annotationName=luaL_checkstring(L, 2);
+    uint64_t pc=luaL_checkinteger(L,3);
+
+    LuaInstructionAnnotation *m_instrAnnotation = static_cast<s2e::plugins::LuaInstructionAnnotation *>(g_s2e->getPlugin("LuaInstructionAnnotation"));
+
+    m_instrAnnotation->initialize();
+    bool ret=m_instrAnnotation->registerAnnotation(moduleId, s2e::plugins::LuaInstructionAnnotation::Annotation(annotationName, pc));
+    lua_pushboolean(L, ret);
+    return 1;
+
 }
 }
 }

--- a/src/s2e/Plugins/Lua/LuaS2EExecutionState.h
+++ b/src/s2e/Plugins/Lua/LuaS2EExecutionState.h
@@ -41,6 +41,7 @@ public:
     int setPluginProperty(lua_State *L);
     int getPluginProperty(lua_State *L);
     int debug(lua_State *L);
+    int registerInstructionAnnotation(lua_State *L);
 };
 }
 }

--- a/src/s2e/Plugins/Lua/LuaS2EExecutionStateMemory.cpp
+++ b/src/s2e/Plugins/Lua/LuaS2EExecutionStateMemory.cpp
@@ -63,6 +63,7 @@ int LuaS2EExecutionStateMemory::readBytes(lua_State *L) {
 
 int LuaS2EExecutionStateMemory::write(lua_State *L) {
     long address = (long) luaL_checkinteger(L, 1);
+    void *expr = luaL_checkudata(L, 2, "LuaExpression");
 
     if (lua_isuserdata(L, 2)) {
         void *expr = luaL_checkudata(L, 2, "LuaExpression");


### PR DESCRIPTION
I added the ability to dynamically register a LuaInstructionAnnotation from Lua. To this extend I made the registerAnnotationFunction of LuaInstructionAnnotation public, note that I also had to change its return value as if one would try to register an annotation twice at the same address s2e would terminate.

Signed-off-by: Sebastian Walla <sebastian.walla@gmx.de>