### PR TITLE
LuaInstructionAnnotation: allow annotations to skip their instruction

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -115,6 +115,8 @@ add_library(
     s2e/Plugins/Lua/LuaFunctionAnnotation.cpp
     s2e/Plugins/Lua/LuaInstructionAnnotation.cpp
     s2e/Plugins/Lua/LuaAnnotationState.cpp
+    s2e/Plugins/Lua/LuaInstructionAnnotationState.cpp
+    s2e/Plugins/Lua/LuaFunctionAnnotationState.cpp
     s2e/Plugins/Lua/LuaExpression.cpp
     s2e/Plugins/Lua/LuaCoreEvents.cpp
 )

--- a/src/s2e/Plugins/Lua/LuaAnnotationState.cpp
+++ b/src/s2e/Plugins/Lua/LuaAnnotationState.cpp
@@ -16,16 +16,9 @@ namespace plugins {
 const char LuaAnnotationState::className[] = "LuaAnnotationState";
 
 Lunar<LuaAnnotationState>::RegType LuaAnnotationState::methods[] = {
-    LUNAR_DECLARE_METHOD(LuaAnnotationState, setSkip),
     LUNAR_DECLARE_METHOD(LuaAnnotationState, isChild),
     LUNAR_DECLARE_METHOD(LuaAnnotationState, setExitCpuLoop),
     {0, 0}};
-
-int LuaAnnotationState::setSkip(lua_State *L) {
-    m_skip = lua_toboolean(L, 1);
-    g_s2e->getDebugStream() << "setSkip " << m_skip << '\n';
-    return 0;
-}
 
 int LuaAnnotationState::isChild(lua_State *L) {
     lua_pushboolean(L, m_child);
@@ -37,5 +30,5 @@ int LuaAnnotationState::setExitCpuLoop(lua_State *L) {
     m_exitCpuLoop = true;
     return 0;
 }
-}
-}
+} // namespace plugins
+} // namespace s2e

--- a/src/s2e/Plugins/Lua/LuaAnnotationState.h
+++ b/src/s2e/Plugins/Lua/LuaAnnotationState.h
@@ -16,7 +16,6 @@ namespace plugins {
 
 class LuaAnnotationState {
 private:
-    bool m_skip;
     bool m_child;
     bool m_exitCpuLoop;
 
@@ -27,26 +26,21 @@ public:
     LuaAnnotationState(lua_State *L) : LuaAnnotationState() {
     }
 
-    LuaAnnotationState() : m_skip(false), m_child(false), m_exitCpuLoop(false) {
+    LuaAnnotationState() : m_child(false), m_exitCpuLoop(false) {
     }
 
     void setChild(bool c) {
         m_child = c;
     }
 
-    bool doSkip() const {
-        return m_skip;
-    }
-
     bool exitCpuLoop() const {
         return m_exitCpuLoop;
     }
 
-    int setSkip(lua_State *L);
     int setExitCpuLoop(lua_State *L);
     int isChild(lua_State *L);
 };
-}
-}
+} // namespace plugins
+} // namespace s2e
 
 #endif

--- a/src/s2e/Plugins/Lua/LuaBindings.cpp
+++ b/src/s2e/Plugins/Lua/LuaBindings.cpp
@@ -9,6 +9,8 @@
 #include <s2e/S2E.h>
 
 #include "LuaAnnotationState.h"
+#include "LuaFunctionAnnotationState.h"
+#include "LuaInstructionAnnotationState.h"
 #include "LuaBindings.h"
 #include "LuaExpression.h"
 #include "LuaModuleDescriptor.h"
@@ -32,6 +34,8 @@ void LuaBindings::initialize() {
     lua_setglobal(L, "g_s2e");
 
     Lunar<LuaAnnotationState>::Register(L);
+    Lunar<LuaFunctionAnnotationState>::Register(L);
+    Lunar<LuaInstructionAnnotationState>::Register(L);
     Lunar<LuaS2EExecutionState>::Register(L);
     Lunar<LuaS2EExecutionStateMemory>::Register(L);
     Lunar<LuaS2EExecutionStateRegisters>::Register(L);

--- a/src/s2e/Plugins/Lua/LuaFunctionAnnotation.cpp
+++ b/src/s2e/Plugins/Lua/LuaFunctionAnnotation.cpp
@@ -109,7 +109,7 @@ void LuaFunctionAnnotation::initialize() {
         std::stringstream ss;
         ss << getConfigKey() << ".annotations." << key;
 
-        std::string moduleId = readStringOrFail(s2e(), ss.str() + ".module_name");
+        std::string moduleId = readStringOrFail(s2e(), ss.str() + ".module_id");
         std::string annotationName = readStringOrFail(s2e(), ss.str() + ".name");
         uint64_t pc = readIntOrFail(s2e(), ss.str() + ".pc");
         unsigned paramCount = readIntOrFail(s2e(), ss.str() + ".param_count");

--- a/src/s2e/Plugins/Lua/LuaFunctionAnnotationState.cpp
+++ b/src/s2e/Plugins/Lua/LuaFunctionAnnotationState.cpp
@@ -1,0 +1,33 @@
+///
+/// Copyright (C) 2014-2015, Cyberhaven
+/// All rights reserved.
+///
+/// Licensed under the Cyberhaven Research License Agreement.
+///
+
+#include <s2e/S2E.h>
+
+#include "LuaFunctionAnnotationState.h"
+
+namespace s2e {
+namespace plugins {
+
+const char LuaFunctionAnnotationState::className[] = "LuaFunctionAnnotationState";
+
+Lunar<LuaFunctionAnnotationState>::RegType LuaFunctionAnnotationState::methods[] = {
+    LUNAR_DECLARE_METHOD(LuaFunctionAnnotationState, skipFunction),
+    LUNAR_DECLARE_METHOD(LuaFunctionAnnotationState, isChild),
+    LUNAR_DECLARE_METHOD(LuaFunctionAnnotationState, setExitCpuLoop),
+    {0, 0}};
+
+int LuaFunctionAnnotationState::skipFunction(lua_State *L) {
+    if (lua_gettop(L) < 1) {
+        m_skip = true;
+    } else {
+        m_skip = lua_toboolean(L, 1);
+    }
+    g_s2e->getDebugStream() << "skipFunction " << m_skip << '\n';
+    return 0;
+}
+} // namespace plugins
+} // namespace s2e

--- a/src/s2e/Plugins/Lua/LuaFunctionAnnotationState.h
+++ b/src/s2e/Plugins/Lua/LuaFunctionAnnotationState.h
@@ -1,0 +1,40 @@
+///
+/// Copyright (C) 2014-2015, Cyberhaven
+/// All rights reserved.
+///
+/// Licensed under the Cyberhaven Research License Agreement.
+///
+
+#ifndef _LUA_S2E_FUNCTION_ANNOTATION_STATE_
+
+#define _LUA_S2E_FUNCTION_ANNOTATION_STATE_
+
+#include "Lua.h"
+#include "LuaAnnotationState.h"
+
+namespace s2e {
+namespace plugins {
+
+class LuaFunctionAnnotationState : public LuaAnnotationState {
+private:
+    bool m_skip;
+
+public:
+    static const char className[];
+    static Lunar<LuaFunctionAnnotationState>::RegType methods[];
+    LuaFunctionAnnotationState(lua_State *L) : LuaAnnotationState(L) {
+    }
+
+    LuaFunctionAnnotationState() : LuaAnnotationState(), m_skip(false) {
+    }
+
+    bool doSkip() const {
+        return m_skip;
+    }
+
+    int skipFunction(lua_State *L);
+};
+} // namespace plugins
+} // namespace s2e
+
+#endif

--- a/src/s2e/Plugins/Lua/LuaInstructionAnnotationState.cpp
+++ b/src/s2e/Plugins/Lua/LuaInstructionAnnotationState.cpp
@@ -1,0 +1,33 @@
+///
+/// Copyright (C) 2014-2015, Cyberhaven
+/// All rights reserved.
+///
+/// Licensed under the Cyberhaven Research License Agreement.
+///
+
+#include <s2e/S2E.h>
+
+#include "LuaInstructionAnnotationState.h"
+
+namespace s2e {
+namespace plugins {
+
+const char LuaInstructionAnnotationState::className[] = "LuaInstructionAnnotationState";
+
+Lunar<LuaInstructionAnnotationState>::RegType LuaInstructionAnnotationState::methods[] = {
+    LUNAR_DECLARE_METHOD(LuaInstructionAnnotationState, skipInstruction),
+    LUNAR_DECLARE_METHOD(LuaInstructionAnnotationState, isChild),
+    LUNAR_DECLARE_METHOD(LuaInstructionAnnotationState, setExitCpuLoop),
+    {0, 0}};
+
+int LuaInstructionAnnotationState::skipInstruction(lua_State *L) {
+    if (lua_gettop(L) < 1) {
+        m_skip = true;
+    } else {
+        m_skip = lua_toboolean(L, 1);
+    }
+    g_s2e->getDebugStream() << "skipInstruction " << m_skip << '\n';
+    return 0;
+}
+} // namespace plugins
+} // namespace s2e

--- a/src/s2e/Plugins/Lua/LuaInstructionAnnotationState.h
+++ b/src/s2e/Plugins/Lua/LuaInstructionAnnotationState.h
@@ -1,0 +1,40 @@
+///
+/// Copyright (C) 2014-2015, Cyberhaven
+/// All rights reserved.
+///
+/// Licensed under the Cyberhaven Research License Agreement.
+///
+
+#ifndef _LUA_S2E_INSTRUCTION_ANNOTATION_STATE_
+
+#define _LUA_S2E_INSTRUCTION_ANNOTATION_STATE_
+
+#include "Lua.h"
+#include "LuaAnnotationState.h"
+
+namespace s2e {
+namespace plugins {
+
+class LuaInstructionAnnotationState : public LuaAnnotationState {
+private:
+    bool m_skip;
+
+public:
+    static const char className[];
+    static Lunar<LuaInstructionAnnotationState>::RegType methods[];
+    LuaInstructionAnnotationState(lua_State *L) : LuaAnnotationState(L) {
+    }
+
+    LuaInstructionAnnotationState() : LuaAnnotationState(), m_skip(false) {
+    }
+
+    bool doSkip() const {
+        return m_skip;
+    }
+
+    int skipInstruction(lua_State *L);
+};
+} // namespace plugins
+} // namespace s2e
+
+#endif


### PR DESCRIPTION
Tested with this:
```
int main(void)
{
	*(volatile char *)0 = 1;
	return 0;
}
```

When compiled with `clang -O3` this is:
```
4004E0                 mov     byte ptr ds:0, 1
4004E8                 xor     eax, eax
4004EA                 retn
```

Using this
```
add_plugin("LuaInstructionAnnotation")

pluginsConfig.LuaInstructionAnnotation = {
        annotations = { test = { pc = 0x4004E0, module_name = "crash", name = "oncrash" } }
}

function oncrash(state, ann)
        ann:setSkip(true)
end
```
makes the program not segfault.

Signed-off-by: Matteo Rizzo <matteo.rizzo@epfl.ch>