### PR TITLE
WindowsMonitor: use KPRCB to get the current thread pointer

### DIFF
--- a/src/s2e/Plugins/OSMonitors/Windows/WindowsMonitor.cpp
+++ b/src/s2e/Plugins/OSMonitors/Windows/WindowsMonitor.cpp
@@ -1038,10 +1038,8 @@ template <typename T>
 static inline bool _ReadCurrentProcessThreadId(Plugin *plg, S2EExecutionState *state,
                                                const S2E_WINMON2_KERNEL_STRUCTS &k, uint64_t *pid, uint64_t *tid,
                                                uint64_t *_pkthread = NULL, uint64_t *_pkprocess = NULL) {
-    // assert(k.PointerSizeInBytes == 8);
-
     T pkthread;
-    if (!state->mem()->read(k.KPCR + k.EThreadSegmentOffset, &pkthread, sizeof(pkthread))) {
+    if (!state->mem()->read(k.KPRCB + k.EThreadSegmentOffset, &pkthread, sizeof(pkthread))) {
         plg->getDebugStream() << "_ReadCurrentProcessThreadId: Could not read KPCR "
                               << hexval(k.KPCR + k.EThreadSegmentOffset) << "\n";
         return false;


### PR DESCRIPTION
Current thread pointer is contained within the PRCB (see http://hypervsir.blogspot.com/2014/09/windows-os-thread-scheduling-monitoring.html, http://www.nirsoft.net/kernel_struct/vista/KPRCB.html, etc.)